### PR TITLE
Catch wrong depth in a ValueError for GKL

### DIFF
--- a/matfree/decomp.py
+++ b/matfree/decomp.py
@@ -174,6 +174,13 @@ def gkl_full_reortho(depth, /, matrix_shape) -> AlgorithmType:
     Decompose a matrix into a product of orthogonal-**bidiagonal**-orthogonal matrices.
     Use this algorithm for approximate **singular value** decompositions.
     """
+    nrows, ncols = matrix_shape
+    max_depth = min(nrows, ncols) - 1
+    if depth > max_depth or depth < 0:
+        msg1 = f"Depth {depth} exceeds the matrix' dimensions. "
+        msg2 = f"Expected: 0 <= depth <= min(nrows, ncols) - 1 = {max_depth} "
+        msg3 = f"for a matrix with shape {matrix_shape}."
+        raise ValueError(msg1 + msg2 + msg3)
     return _DecompAlg(
         init=func.partial(_gkl_full_reortho_init, depth, matrix_shape),
         step=_gkl_full_reortho_apply,

--- a/tests/test_decomp/test_gkl_full_reortho.py
+++ b/tests/test_decomp/test_gkl_full_reortho.py
@@ -110,6 +110,4 @@ def test_no_error_zero_depth(A):
     assert np.shape(d_m) == (1,)
     assert np.shape(e_m) == (0,)
     assert np.shape(b) == ()
-    assert np.shape(
-        v,
-    ) == (ncols,)
+    assert np.shape(v) == (ncols,)

--- a/tests/test_decomp/test_gkl_full_reortho.py
+++ b/tests/test_decomp/test_gkl_full_reortho.py
@@ -63,3 +63,53 @@ def _bidiagonal_dense(d, e):
     diag = linalg.diagonal_matrix(d)
     offdiag = linalg.diagonal_matrix(e, 1)
     return diag + offdiag
+
+
+@testing.parametrize("nrows", [5])
+@testing.parametrize("ncols", [3])
+@testing.parametrize("num_significant_singular_vals", [3])
+def test_error_too_high_depth(A):
+    """Assert that a ValueError is raised when the depth exceeds the matrix size."""
+    nrows, ncols = np.shape(A)
+    max_depth = min(nrows, ncols) - 1
+
+    with testing.raises(ValueError):
+        _ = decomp.gkl_full_reortho(max_depth + 1, matrix_shape=np.shape(A))
+
+
+@testing.parametrize("nrows", [5])
+@testing.parametrize("ncols", [3])
+@testing.parametrize("num_significant_singular_vals", [3])
+def test_error_too_low_depth(A):
+    """Assert that a ValueError is raised when the depth is negative."""
+    min_depth = 0
+    with testing.raises(ValueError):
+        _ = decomp.gkl_full_reortho(min_depth - 1, matrix_shape=np.shape(A))
+
+
+@testing.parametrize("nrows", [15])
+@testing.parametrize("ncols", [3])
+@testing.parametrize("num_significant_singular_vals", [3])
+def test_no_error_zero_depth(A):
+    """Assert the corner case of zero-depth does not raise an error."""
+    nrows, ncols = np.shape(A)
+    algorithm = decomp.gkl_full_reortho(0, matrix_shape=np.shape(A))
+    key = prng.prng_key(1)
+    v0 = prng.normal(key, shape=(ncols,))
+
+    def Av(v):
+        return A @ v
+
+    def vA(v):
+        return v @ A
+
+    Us, Bs, Vs, (b, v) = decomp.decompose_fori_loop(v0, Av, vA, algorithm=algorithm)
+    (d_m, e_m) = Bs
+    assert np.shape(Us) == (nrows, 1)
+    assert np.shape(Vs) == (1, ncols)
+    assert np.shape(d_m) == (1,)
+    assert np.shape(e_m) == (0,)
+    assert np.shape(b) == ()
+    assert np.shape(
+        v,
+    ) == (ncols,)


### PR DESCRIPTION
Resolves #138 