### PR TITLE
Update required python versions and update pre-commit hook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.9.1
     hooks:
       - id: black
         language_version: python3
@@ -20,15 +20,15 @@ repos:
       - id: isort
         name: isort
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.265
+    rev: v0.0.292
     hooks:
       - id: ruff
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.2.0
+    rev: v1.5.1
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
   - repo: https://github.com/lyz-code/yamlfix/
-    rev: 1.9.0
+    rev: 1.13.0
     hooks:
       - id: yamlfix

--- a/matfree/backend/typing.py
+++ b/matfree/backend/typing.py
@@ -1,7 +1,7 @@
 """Types."""
 # fmt: off
 from collections.abc import Callable  # noqa: F401
-from typing import Any, Generic, Iterable, Sequence, Tuple, TypeVar  # noqa: F401
+from typing import Any, Generic, Iterable, Sequence, Tuple, TypeVar  # noqa: F401, UP035
 
 from jax import Array  # noqa: F401
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Matrix-free numerical linear algebra."
 readme = "README.md"
-requires-python=">=3.8"
+requires-python=">=3.9"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Now running with python 3.9+ instead of 3.8+ because this is what JAX requires. 