### PR TITLE
Implement validation of a unit two norm in Lanczos-style decompositions

### DIFF
--- a/matfree/backend/np.py
+++ b/matfree/backend/np.py
@@ -83,6 +83,10 @@ def any(x, /):  # noqa: A001
     return jnp.any(x)
 
 
+def all(x, /):  # noqa: A001
+    return jnp.all(x)
+
+
 def allclose(x1, x2, /, *, rtol=1e-5, atol=1e-8):
     return jnp.allclose(x1, x2, rtol=rtol, atol=atol)
 
@@ -156,6 +160,10 @@ def dtype(x, /):
 
 def nan():
     return jnp.nan
+
+
+def finfo_eps(x, /):
+    return jnp.finfo(x).eps
 
 
 # Others

--- a/matfree/slq.py
+++ b/matfree/slq.py
@@ -25,6 +25,7 @@ def integrand_slq_spd(matfun, order, matvec, /):
 
     def quadform(v0, *parameters):
         v0_flat, v_unflatten = tree_util.ravel_pytree(v0)
+        v0_flat /= linalg.vector_norm(v0_flat)
 
         def matvec_flat(v_flat):
             v = v_unflatten(v_flat)
@@ -85,6 +86,7 @@ def integrand_slq_product(matfun, depth, matvec, vecmat, /):
 
     def quadform(v0, *parameters):
         v0_flat, v_unflatten = tree_util.ravel_pytree(v0)
+        v0_flat /= linalg.vector_norm(v0_flat)
 
         def matvec_flat(v_flat):
             v = v_unflatten(v_flat)

--- a/tests/test_decomp/test_bidiagonal_full_reortho.py
+++ b/tests/test_decomp/test_bidiagonal_full_reortho.py
@@ -1,4 +1,4 @@
-"""Tests for GKL bidiagonalisation."""
+"""Test the Golub-Kahan-Lanczos bi-diagonalisation with full re-orthogonalisation."""
 
 from matfree import decomp, test_util
 from matfree.backend import linalg, np, prng, testing

--- a/tests/test_decomp/test_svd.py
+++ b/tests/test_decomp/test_svd.py
@@ -34,6 +34,7 @@ def test_equal_to_linalg_svd(A):
         return v @ A
 
     v0 = np.ones((ncols,))
+    v0 /= linalg.vector_norm(v0)
     U, S, Vt = decomp.svd_approx(v0, depth, Av, vA, matrix_shape=np.shape(A))
     U_, S_, Vt_ = linalg.svd(A, full_matrices=False)
 

--- a/tests/test_decomp/test_tridiagonal_full_reortho.py
+++ b/tests/test_decomp/test_tridiagonal_full_reortho.py
@@ -1,4 +1,4 @@
-"""Tests for Lanczos functionality."""
+"""Test the Lanczos tri-diagonalisation with full re-orthogonalisation."""
 
 from matfree import decomp, test_util
 from matfree.backend import linalg, np, prng, testing


### PR DESCRIPTION
This is an assumption in the algorithm.

This PR introduces a new flag for the two Lanczos-algorithms (validate_unit_2_norm=True/False), which check the norm of the input and mark it as unusable if the norm is not 1. The default is False, which is backward-compatible. 