### PR TITLE
Merge decomposition-algorithms with decompose_fori_loop

### DIFF
--- a/tests/test_lanczos/test_alg_bidiagonal_full_reortho.py
+++ b/tests/test_lanczos/test_alg_bidiagonal_full_reortho.py
@@ -30,9 +30,9 @@ def test_lanczos_bidiag_full_reortho(A, order):
     def vA(v):
         return v @ A
 
-    alg = lanczos.alg_bidiag_full_reortho(Av, vA, order, matrix_shape=np.shape(A))
+    algorithm = lanczos.alg_bidiag_full_reortho(Av, vA, order, matrix_shape=np.shape(A))
     v0 /= linalg.vector_norm(v0)
-    Us, Bs, Vs, (b, v) = lanczos.decompose_fori_loop(v0, algorithm=alg)
+    Us, Bs, Vs, (b, v) = algorithm(v0)
     (d_m, e_m) = Bs
 
     tols_decomp = {"atol": 1e-5, "rtol": 1e-5}
@@ -116,7 +116,7 @@ def test_no_error_zero_depth(A):
         return v @ A
 
     algorithm = lanczos.alg_bidiag_full_reortho(Av, vA, 0, matrix_shape=np.shape(A))
-    Us, Bs, Vs, (b, v) = lanczos.decompose_fori_loop(v0, algorithm=algorithm)
+    Us, Bs, Vs, (b, v) = algorithm(v0)
     (d_m, e_m) = Bs
     assert np.shape(Us) == (nrows, 1)
     assert np.shape(Vs) == (1, ncols)
@@ -147,7 +147,7 @@ def test_validate_unit_norm(A, order):
     algorithm = lanczos.alg_bidiag_full_reortho(
         Av, vA, order, matrix_shape=np.shape(A), validate_unit_2_norm=True
     )
-    Us, (d_m, e_m), Vs, (b, v) = lanczos.decompose_fori_loop(v0, algorithm=algorithm)
+    Us, (d_m, e_m), Vs, (b, v) = algorithm(v0)
 
     # Since v0 is not normalized, all inputs are NaN
     for x in (Us, d_m, e_m, Vs, b, v):

--- a/tests/test_lanczos/test_alg_tridiagonal_full_reortho.py
+++ b/tests/test_lanczos/test_alg_tridiagonal_full_reortho.py
@@ -23,8 +23,8 @@ def test_max_order(A):
     key = prng.prng_key(1)
     v0 = prng.normal(key, shape=(n,))
     v0 /= linalg.vector_norm(v0)
-    alg = lanczos.alg_tridiag_full_reortho(lambda v: A @ v, order)
-    Q, (d_m, e_m) = lanczos.decompose_fori_loop(v0, algorithm=alg)
+    algorithm = lanczos.alg_tridiag_full_reortho(lambda v: A @ v, order)
+    Q, (d_m, e_m) = algorithm(v0)
 
     # Lanczos is not stable.
     tols_decomp = {"atol": 1e-5, "rtol": 1e-5}
@@ -65,8 +65,8 @@ def test_identity(A, order):
     key = prng.prng_key(1)
     v0 = prng.normal(key, shape=(n,))
     v0 /= linalg.vector_norm(v0)
-    alg = lanczos.alg_tridiag_full_reortho(lambda v: A @ v, order)
-    Q, tridiag = lanczos.decompose_fori_loop(v0, algorithm=alg)
+    algorithm = lanczos.alg_tridiag_full_reortho(lambda v: A @ v, order)
+    Q, tridiag = algorithm(v0)
     (d_m, e_m) = tridiag
 
     # Lanczos is not stable.
@@ -107,10 +107,10 @@ def test_validate_unit_norm(A, order):
     # Not normalized!
     v0 = prng.normal(key, shape=(n,)) + 1.0
 
-    alg = lanczos.alg_tridiag_full_reortho(
+    algorithm = lanczos.alg_tridiag_full_reortho(
         lambda v: A @ v, order, validate_unit_2_norm=True
     )
-    Q, (d_m, e_m) = lanczos.decompose_fori_loop(v0, algorithm=alg)
+    Q, (d_m, e_m) = algorithm(v0)
 
     # Since v0 is not normalized, all inputs are NaN
     for x in (Q, d_m, e_m):

--- a/tests/test_lanczos/test_alg_tridiagonal_full_reortho.py
+++ b/tests/test_lanczos/test_alg_tridiagonal_full_reortho.py
@@ -23,8 +23,8 @@ def test_max_order(A):
     key = prng.prng_key(1)
     v0 = prng.normal(key, shape=(n,))
     v0 /= linalg.vector_norm(v0)
-    alg = lanczos.alg_tridiag_full_reortho(order)
-    Q, (d_m, e_m) = lanczos.decompose_fori_loop(v0, lambda v: A @ v, algorithm=alg)
+    alg = lanczos.alg_tridiag_full_reortho(lambda v: A @ v, order)
+    Q, (d_m, e_m) = lanczos.decompose_fori_loop(v0, algorithm=alg)
 
     # Lanczos is not stable.
     tols_decomp = {"atol": 1e-5, "rtol": 1e-5}
@@ -65,8 +65,8 @@ def test_identity(A, order):
     key = prng.prng_key(1)
     v0 = prng.normal(key, shape=(n,))
     v0 /= linalg.vector_norm(v0)
-    alg = lanczos.alg_tridiag_full_reortho(order)
-    Q, tridiag = lanczos.decompose_fori_loop(v0, lambda v: A @ v, algorithm=alg)
+    alg = lanczos.alg_tridiag_full_reortho(lambda v: A @ v, order)
+    Q, tridiag = lanczos.decompose_fori_loop(v0, algorithm=alg)
     (d_m, e_m) = tridiag
 
     # Lanczos is not stable.
@@ -107,8 +107,10 @@ def test_validate_unit_norm(A, order):
     # Not normalized!
     v0 = prng.normal(key, shape=(n,)) + 1.0
 
-    alg = lanczos.alg_tridiag_full_reortho(order, validate_unit_2_norm=True)
-    Q, (d_m, e_m) = lanczos.decompose_fori_loop(v0, lambda v: A @ v, algorithm=alg)
+    alg = lanczos.alg_tridiag_full_reortho(
+        lambda v: A @ v, order, validate_unit_2_norm=True
+    )
+    Q, (d_m, e_m) = lanczos.decompose_fori_loop(v0, algorithm=alg)
 
     # Since v0 is not normalized, all inputs are NaN
     for x in (Q, d_m, e_m):


### PR DESCRIPTION
As the title states.

This PR breaks backwards compatibility (but the next release is already breaking, so we might as well make the remaining breaking changes now).

Why?
Because both decompose_fori_loop, as well as the Lanczos-decomposition algorithms, have always been closely tied together (one did not work without the other). Now, this is more clear because only one of them is public.

As a side result, matrix-decomposition algorithms now implement parametrised matrix-vector products, and the matrix-decomposition algorithms share an output type with Hutchinson-, Lanczos-, and Chebyshev-style methods.

