### PR TITLE
Rename lanczos.integrand_* functions

### DIFF
--- a/matfree/lanczos.py
+++ b/matfree/lanczos.py
@@ -28,15 +28,15 @@ from matfree.backend import containers, control_flow, func, linalg, np, tree_uti
 from matfree.backend.typing import Array, Callable, Tuple
 
 
-def integrand_logdet_spd(order, matvec, /):
+def integrand_spd_logdet(order, matvec, /):
     """Construct the integrand for the log-determinant.
 
     This function assumes a symmetric, positive definite matrix.
     """
-    return integrand_slq_spd(np.log, order, matvec)
+    return integrand_spd(np.log, order, matvec)
 
 
-def integrand_slq_spd(matfun, order, matvec, /):
+def integrand_spd(matfun, order, matvec, /):
     """Quadratic form for stochastic Lanczos quadrature.
 
     This function assumes a symmetric, positive definite matrix.
@@ -65,25 +65,25 @@ def integrand_slq_spd(matfun, order, matvec, /):
     return quadform
 
 
-def integrand_logdet_product(depth, matvec, vecmat, /):
+def integrand_product_logdet(depth, matvec, vecmat, /):
     r"""Construct the integrand for the log-determinant of a matrix-product.
 
     Here, "product" refers to $X = A^\top A$.
     """
-    return integrand_slq_product(np.log, depth, matvec, vecmat)
+    return integrand_product(np.log, depth, matvec, vecmat)
 
 
-def integrand_schatten_norm(power, depth, matvec, vecmat, /):
+def integrand_product_schatten_norm(power, depth, matvec, vecmat, /):
     r"""Construct the integrand for the p-th power of the Schatten-p norm."""
 
     def matfun(x):
         """Matrix-function for Schatten-p norms."""
         return x ** (power / 2)
 
-    return integrand_slq_product(matfun, depth, matvec, vecmat)
+    return integrand_product(matfun, depth, matvec, vecmat)
 
 
-def integrand_slq_product(matfun, depth, matvec, vecmat, /):
+def integrand_product(matfun, depth, matvec, vecmat, /):
     r"""Construct the integrand for the trace of a function of a matrix-product.
 
     Instead of the trace of a function of a matrix,

--- a/tests/test_lanczos/test_integrand_logdet_product.py
+++ b/tests/test_lanczos/test_integrand_logdet_product.py
@@ -31,7 +31,7 @@ def test_logdet_product(A, order):
 
     x_like = {"fx": np.ones((ncols,), dtype=float)}
     fun = hutchinson.sampler_normal(x_like, num=400)
-    problem = lanczos.integrand_logdet_product(order, matvec, vecmat)
+    problem = lanczos.integrand_product_logdet(order, matvec, vecmat)
     estimate = hutchinson.hutchinson(problem, fun)
     received = estimate(key)
 
@@ -53,7 +53,7 @@ def test_logdet_product_exact_for_full_order_lanczos(n):
 
     # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
     order = n - 1
-    integrand = lanczos.integrand_logdet_product(
+    integrand = lanczos.integrand_product_logdet(
         order, lambda v: A @ v, lambda v: v @ A
     )
 

--- a/tests/test_lanczos/test_integrand_logdet_spd.py
+++ b/tests/test_lanczos/test_integrand_logdet_spd.py
@@ -29,7 +29,7 @@ def test_logdet_spd(A, order):
     key = prng.prng_key(1)
     args_like = {"fx": np.ones((n,), dtype=float)}
     sampler = hutchinson.sampler_normal(args_like, num=10)
-    integrand = lanczos.integrand_logdet_spd(order, matvec)
+    integrand = lanczos.integrand_spd_logdet(order, matvec)
     estimate = hutchinson.hutchinson(integrand, sampler)
     received = estimate(key)
 
@@ -49,7 +49,7 @@ def test_logdet_spd_exact_for_full_order_lanczos(n):
 
     # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
     order = n - 1
-    integrand = lanczos.integrand_logdet_spd(order, lambda v: A @ v)
+    integrand = lanczos.integrand_spd_logdet(order, lambda v: A @ v)
 
     # Construct a vector without that does not have expected 2-norm equal to "dim"
     x = prng.normal(prng.prng_key(seed=1), shape=(n,)) + 10

--- a/tests/test_lanczos/test_integrand_schatten_norm.py
+++ b/tests/test_lanczos/test_integrand_schatten_norm.py
@@ -27,7 +27,7 @@ def test_schatten_norm(A, order, power):
     _, ncols = np.shape(A)
     args_like = np.ones((ncols,), dtype=float)
     sampler = hutchinson.sampler_normal(args_like, num=500)
-    integrand = lanczos.integrand_schatten_norm(
+    integrand = lanczos.integrand_product_schatten_norm(
         power, order, lambda v: A @ v, lambda v: A.T @ v
     )
     estimate = hutchinson.hutchinson(integrand, sampler)

--- a/tutorials/1_log_determinants.py
+++ b/tutorials/1_log_determinants.py
@@ -27,7 +27,7 @@ x_like = jnp.ones((nrows,), dtype=float)  # use to determine shapes of vectors
 # Estimate log-determinants with stochastic Lanczos quadrature.
 
 order = 3
-problem = lanczos.integrand_logdet_spd(order, matvec)
+problem = lanczos.integrand_spd_logdet(order, matvec)
 sampler = hutchinson.sampler_normal(x_like, num=1_000)
 estimator = hutchinson.hutchinson(problem, sample_fun=sampler)
 logdet = estimator(jax.random.PRNGKey(1))
@@ -58,7 +58,7 @@ def vecmat_left(x):
 
 
 order = 3
-problem = lanczos.integrand_logdet_product(order, matvec_right, vecmat_left)
+problem = lanczos.integrand_product_logdet(order, matvec_right, vecmat_left)
 sampler = hutchinson.sampler_normal(x_like, num=1_000)
 estimator = hutchinson.hutchinson(problem, sample_fun=sampler)
 logdet = estimator(jax.random.PRNGKey(1))

--- a/tutorials/2_pytree_logdeterminants.py
+++ b/tutorials/2_pytree_logdeterminants.py
@@ -53,7 +53,7 @@ def make_matvec(alpha):
 
 matvec = make_matvec(alpha=0.1)
 order = 3
-integrand = lanczos.integrand_logdet_spd(order, matvec)
+integrand = lanczos.integrand_spd_logdet(order, matvec)
 sample_fun = hutchinson.sampler_normal(f0, num=10)
 estimator = hutchinson.hutchinson(integrand, sample_fun=sample_fun)
 key = jax.random.PRNGKey(1)


### PR DESCRIPTION
Rename stochastic Lanczos quadrature functions:

* `integrand*_spd` -> `integrand_spd*` 
* `integrand*_product` -> `integrand_product*` 

Now, related functions are grouped together in the documentation. 