### PR TITLE
Deprecate matfree.pinv

### DIFF
--- a/matfree/backend/testing.py
+++ b/matfree/backend/testing.py
@@ -23,3 +23,7 @@ def check_grads(fun, /, args, *, order, atol, rtol):
 
 def raises(err, /):
     return pytest.raises(err)
+
+
+def warns(warning, /):
+    return pytest.warns(warning)

--- a/matfree/pinv.py
+++ b/matfree/pinv.py
@@ -1,6 +1,18 @@
 """Pseudo-inverses of linear operators."""
 
+import warnings
+
 from matfree.backend.typing import Callable
+
+
+def _warn_deprecated():
+    msg = "The module matfree.pinv has been deprecated and will be removed soon. "
+    msg += "The removal will happen either in v0.0.17 or in v0.1.0, "
+    msg += "depending on what comes first. "
+    msg += "If your code relies on matfree.pinv, create an issue *now*."
+
+    warnings.warn(msg, DeprecationWarning, stacklevel=1)
+
 
 # todo: what happens if we want to reuse e.g. LU decompositions of AA^*?
 # todo: should we not just return pinv-matvec but also pinv-vecmat?
@@ -28,6 +40,7 @@ def pinv_tall(Av: Callable, vA: Callable, *, solve: Callable) -> Callable:
         Matrix-vector product function that implements
         the pseudo-inverse of the matrix-vector product function `Av`.
     """
+    _warn_deprecated()
 
     def pinv(s):
         return vA(solve(lambda v: Av(vA(v)), s))
@@ -57,6 +70,7 @@ def pinv_wide(Av: Callable, vA: Callable, *, solve: Callable) -> Callable:
         Matrix-vector product function that implements
         the pseudo-inverse of the matrix-vector product function `Av`.
     """
+    _warn_deprecated()
 
     def pinv(s):
         return solve(lambda v: vA(Av(v)), vA(s))

--- a/tests/test_pinv/test_pseudo_inverse_correct.py
+++ b/tests/test_pinv/test_pseudo_inverse_correct.py
@@ -4,25 +4,31 @@ from matfree import pinv
 from matfree.backend import func, linalg, np, prng, testing
 
 
-def fun_tall(x):
-    """Evaluate a nonlinear function with a tall Jacobian."""
-    P = prng.uniform(prng.prng_key(seed=2), shape=(len(x) - 2, len(x)))
-    return np.cos(P @ np.sin(x))
+def case_tall():
+    def fun(x):
+        """Evaluate a nonlinear function with a tall Jacobian."""
+        P = prng.uniform(prng.prng_key(seed=2), shape=(len(x) - 2, len(x)))
+        return np.cos(P @ np.sin(x))
+
+    return fun, pinv.pinv_tall
 
 
-def fun_wide(x):
-    """Evaluate a nonlinear function with a wide Jacobian."""
-    P = prng.uniform(prng.prng_key(seed=2), shape=(len(x) + 2, len(x)))
-    return np.cos(P @ np.sin(x))
+def case_wide():
+    def fun(x):
+        """Evaluate a nonlinear function with a wide Jacobian."""
+        P = prng.uniform(prng.prng_key(seed=2), shape=(len(x) + 2, len(x)))
+        return np.cos(P @ np.sin(x))
+
+    return fun, pinv.pinv_wide
 
 
-def densify(fun, input_dim):
+def materialise(fun, input_dim):
     """Densify a linear operator."""
     return func.vmap(fun, in_axes=-1, out_axes=-1)(np.eye(input_dim))
 
 
 def solve_dense(Av, b):
-    """Solve a linear system by densifying + LU decomposition."""
+    """Solve a linear system by materialising + LU decomposition."""
     return linalg.solve(func.jacfwd(Av)(b), b)
 
 
@@ -31,21 +37,21 @@ def solve_cg(Av, b):
     return linalg.cg(Av, b)[0]
 
 
-@testing.parametrize(
-    "fun, pinv_fun", ([fun_tall, pinv.pinv_tall], [fun_wide, pinv.pinv_wide])
-)
+@testing.parametrize_with_cases("fun_and_pinv", cases=".", prefix="case_")
 @testing.parametrize("solve_fun", [solve_dense, solve_cg])
-def test_inverse_correct(fun, pinv_fun, solve_fun):
+def test_inverse_correct(fun_and_pinv, solve_fun):
     """Compare the values of the computed pseudo-inverses to numpy.pinv()."""
+    fun, pinv_fun = fun_and_pinv
     key = prng.prng_key(seed=1)
     x = prng.uniform(key, shape=(7,))
 
     J = func.jacfwd(fun)(x)
 
     # Invert
-    inverse = pinv_fun(lambda v: J @ v, lambda v: v @ J, solve=solve_fun)
+    with testing.warns(DeprecationWarning):
+        inverse = pinv_fun(lambda v: J @ v, lambda v: v @ J, solve=solve_fun)
 
     # Dense invert
-    inverse_matrix = densify(inverse, len(fun(x)))
+    inverse_matrix = materialise(inverse, len(fun(x)))
     inverse_expected = linalg.pinv(func.jacfwd(fun)(x))
     assert np.allclose(inverse_matrix, inverse_expected, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
I have never used it, I suspect no one else has ever used it, and it clutters the namespace.

It will be removed in v0.0.17 or v0.1.0, whichever happens first.

If someone needs it, please create an issue.