### PR TITLE
Create dedicated `funm` and `funm_trace` modules for functions of matrices

### DIFF
--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -1,14 +1,11 @@
-"""Approximate matrix-function-vector products with polynomial expansions.
+"""Functions of matrices."""
 
-This module does not include Lanczos-style approximations, which are
-in [matfree.lanczos][matfree.lanczos].
-"""
-
-from matfree.backend import containers, control_flow, np
+from matfree import lanczos
+from matfree.backend import containers, control_flow, func, linalg, np
 from matfree.backend.typing import Array
 
 
-def funm_vector_product_chebyshev(matfun, order, matvec, /):
+def funm_chebyshev(matfun, order, matvec, /):
     """Compute a matrix-function-vector product via Chebyshev's algorithm.
 
     This function assumes that the **spectrum of the matrix-vector product
@@ -56,7 +53,7 @@ def funm_vector_product_chebyshev(matfun, order, matvec, /):
         return val.interpolation
 
     alg = (0, order - 1), init_func, recursion_func, extract_func
-    return _funm_vector_product_polyexpand(alg)
+    return _funm_polyexpand(alg)
 
 
 def _chebyshev_nodes(n, /):
@@ -64,7 +61,7 @@ def _chebyshev_nodes(n, /):
     return np.cos((2 * k - 1) / (2 * n) * np.pi())
 
 
-def _funm_vector_product_polyexpand(matrix_poly_alg, /):
+def _funm_polyexpand(matrix_poly_alg, /):
     """Implement a matrix-function-vector product via a polynomial expansion."""
     (lower, upper), init_func, step_func, extract_func = matrix_poly_alg
 
@@ -78,3 +75,35 @@ def _funm_vector_product_polyexpand(matrix_poly_alg, /):
         return extract_func(final_state)
 
     return matvec
+
+
+def funm_lanczos_spd(matfun, order, matvec, /):
+    """Implement a matrix-function-vector product via Lanczos' algorithm.
+
+    This algorithm uses Lanczos' tridiagonalisation with full re-orthogonalisation
+    and therefore applies only to symmetric, positive definite matrices.
+    """
+    algorithm = lanczos.alg_tridiag_full_reortho(matvec, order)
+
+    def estimate(vec, *parameters):
+        length = linalg.vector_norm(vec)
+        vec /= length
+        basis, (diag, off_diag) = algorithm(vec, *parameters)
+        eigvals, eigvecs = _eigh_tridiag(diag, off_diag)
+
+        fx_eigvals = func.vmap(matfun)(eigvals)
+        return length * (basis.T @ (eigvecs @ (fx_eigvals * eigvecs[0, :])))
+
+    return estimate
+
+
+def _eigh_tridiag(diag, off_diag):
+    # todo: once jax supports eigh_tridiagonal(eigvals_only=False),
+    #  use it here. Until then: an eigen-decomposition of size (order + 1)
+    #  does not hurt too much...
+    diag = linalg.diagonal_matrix(diag)
+    offdiag1 = linalg.diagonal_matrix(off_diag, -1)
+    offdiag2 = linalg.diagonal_matrix(off_diag, 1)
+    dense_matrix = diag + offdiag1 + offdiag2
+    eigvals, eigvecs = linalg.eigh(dense_matrix)
+    return eigvals, eigvecs

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -1,4 +1,22 @@
-"""Functions of matrices."""
+"""Functions of matrices implemented as matrix-function-vector products.
+
+
+Examples
+--------
+>>> import jax.random
+>>> import jax.numpy as jnp
+>>>
+>>> jnp.set_printoptions(1)
+>>>
+>>> M = jax.random.normal(jax.random.PRNGKey(1), shape=(10, 10))
+>>> A = M.T @ M
+>>> v = jax.random.normal(jax.random.PRNGKey(2), shape=(10,))
+>>>
+>>> # Compute a matrix-logarithm with Lanczos' algorithm
+>>> matfun_vec = funm_lanczos_spd(jnp.log, 4, lambda s: A @ s)
+>>> matfun_vec(v)
+Array([-4. , -2.1, -2.7, -1.9, -1.3, -3.5, -0.5, -0.1,  0.3,  1.5],      dtype=float32)
+"""
 
 from matfree import lanczos
 from matfree.backend import containers, control_flow, func, linalg, np

--- a/matfree/funm_trace.py
+++ b/matfree/funm_trace.py
@@ -1,7 +1,15 @@
-"""Stochastic estimation of traces of functions of matrices."""
+"""Stochastic estimation of traces of functions of matrices.
+
+This module extends [matfree.hutchinson][matfree.hutchinson].
+
+"""
 
 from matfree import lanczos
 from matfree.backend import func, linalg, np, tree_util
+
+# todo: currently, all dense matrix-functions are computed
+#  via eigh(). But for e.g. log and exp, we might want to do
+#  something else.
 
 
 def integrand_spd_logdet(order, matvec, /):

--- a/matfree/funm_trace.py
+++ b/matfree/funm_trace.py
@@ -1,0 +1,124 @@
+"""Stochastic estimation of traces of functions of matrices."""
+
+from matfree import lanczos
+from matfree.backend import func, linalg, np, tree_util
+
+
+def integrand_spd_logdet(order, matvec, /):
+    """Construct the integrand for the log-determinant.
+
+    This function assumes a symmetric, positive definite matrix.
+    """
+    return integrand_spd(np.log, order, matvec)
+
+
+def integrand_spd(matfun, order, matvec, /):
+    """Quadratic form for stochastic Lanczos quadrature.
+
+    This function assumes a symmetric, positive definite matrix.
+    """
+
+    def quadform(v0, *parameters):
+        v0_flat, v_unflatten = tree_util.ravel_pytree(v0)
+        length = linalg.vector_norm(v0_flat)
+        v0_flat /= length
+
+        def matvec_flat(v_flat, *p):
+            v = v_unflatten(v_flat)
+            Av = matvec(v, *p)
+            flat, unflatten = tree_util.ravel_pytree(Av)
+            return flat
+
+        algorithm = lanczos.alg_tridiag_full_reortho(matvec_flat, order)
+        _, (diag, off_diag) = algorithm(v0_flat, *parameters)
+        eigvals, eigvecs = _eigh_tridiag(diag, off_diag)
+
+        # Since Q orthogonal (orthonormal) to v0, Q v = Q[0],
+        # and therefore (Q v)^T f(D) (Qv) = Q[0] * f(diag) * Q[0]
+        fx_eigvals = func.vmap(matfun)(eigvals)
+        return length**2 * linalg.vecdot(eigvecs[0, :], fx_eigvals * eigvecs[0, :])
+
+    return quadform
+
+
+def integrand_product_logdet(depth, matvec, vecmat, /):
+    r"""Construct the integrand for the log-determinant of a matrix-product.
+
+    Here, "product" refers to $X = A^\top A$.
+    """
+    return integrand_product(np.log, depth, matvec, vecmat)
+
+
+def integrand_product_schatten_norm(power, depth, matvec, vecmat, /):
+    r"""Construct the integrand for the p-th power of the Schatten-p norm."""
+
+    def matfun(x):
+        """Matrix-function for Schatten-p norms."""
+        return x ** (power / 2)
+
+    return integrand_product(matfun, depth, matvec, vecmat)
+
+
+def integrand_product(matfun, depth, matvec, vecmat, /):
+    r"""Construct the integrand for the trace of a function of a matrix-product.
+
+    Instead of the trace of a function of a matrix,
+    compute the trace of a function of the product of matrices.
+    Here, "product" refers to $X = A^\top A$.
+    """
+
+    def quadform(v0, *parameters):
+        v0_flat, v_unflatten = tree_util.ravel_pytree(v0)
+        length = linalg.vector_norm(v0_flat)
+        v0_flat /= length
+
+        def matvec_flat(v_flat, *p):
+            v = v_unflatten(v_flat)
+            Av = matvec(v, *p)
+            flat, unflatten = tree_util.ravel_pytree(Av)
+            return flat, tree_util.partial_pytree(unflatten)
+
+        w0_flat, w_unflatten = func.eval_shape(matvec_flat, v0_flat)
+        matrix_shape = (*np.shape(w0_flat), *np.shape(v0_flat))
+
+        def vecmat_flat(w_flat):
+            w = w_unflatten(w_flat)
+            wA = vecmat(w, *parameters)
+            return tree_util.ravel_pytree(wA)[0]
+
+        # Decompose into orthogonal-bidiag-orthogonal
+        algorithm = lanczos.alg_bidiag_full_reortho(
+            lambda v: matvec_flat(v)[0], vecmat_flat, depth, matrix_shape=matrix_shape
+        )
+        output = algorithm(v0_flat, *parameters)
+        u, (d, e), vt, _ = output
+
+        # Compute SVD of factorisation
+        B = _bidiagonal_dense(d, e)
+        _, S, Vt = linalg.svd(B, full_matrices=False)
+
+        # Since Q orthogonal (orthonormal) to v0, Q v = Q[0],
+        # and therefore (Q v)^T f(D) (Qv) = Q[0] * f(diag) * Q[0]
+        eigvals, eigvecs = S**2, Vt.T
+        fx_eigvals = func.vmap(matfun)(eigvals)
+        return length**2 * linalg.vecdot(eigvecs[0, :], fx_eigvals * eigvecs[0, :])
+
+    return quadform
+
+
+def _bidiagonal_dense(d, e):
+    diag = linalg.diagonal_matrix(d)
+    offdiag = linalg.diagonal_matrix(e, 1)
+    return diag + offdiag
+
+
+def _eigh_tridiag(diag, off_diag):
+    # todo: once jax supports eigh_tridiagonal(eigvals_only=False),
+    #  use it here. Until then: an eigen-decomposition of size (order + 1)
+    #  does not hurt too much...
+    diag = linalg.diagonal_matrix(diag)
+    offdiag1 = linalg.diagonal_matrix(off_diag, -1)
+    offdiag2 = linalg.diagonal_matrix(off_diag, 1)
+    dense_matrix = diag + offdiag1 + offdiag2
+    eigvals, eigvecs = linalg.eigh(dense_matrix)
+    return eigvals, eigvecs

--- a/matfree/hutchinson.py
+++ b/matfree/hutchinson.py
@@ -1,4 +1,4 @@
-"""Hutchinson-style estimation."""
+"""Stochastic estimation of traces, diagonals, and more."""
 
 from matfree.backend import func, linalg, np, prng, tree_util
 

--- a/matfree/lanczos.py
+++ b/matfree/lanczos.py
@@ -24,148 +24,8 @@ Examples
 Array([-4. , -2.1, -2.7, -1.9, -1.3, -3.5, -0.5, -0.1,  0.3,  1.5],      dtype=float32)
 """
 
-from matfree.backend import containers, control_flow, func, linalg, np, tree_util
+from matfree.backend import containers, control_flow, func, linalg, np
 from matfree.backend.typing import Array, Callable, Tuple
-
-
-def integrand_spd_logdet(order, matvec, /):
-    """Construct the integrand for the log-determinant.
-
-    This function assumes a symmetric, positive definite matrix.
-    """
-    return integrand_spd(np.log, order, matvec)
-
-
-def integrand_spd(matfun, order, matvec, /):
-    """Quadratic form for stochastic Lanczos quadrature.
-
-    This function assumes a symmetric, positive definite matrix.
-    """
-
-    def quadform(v0, *parameters):
-        v0_flat, v_unflatten = tree_util.ravel_pytree(v0)
-        length = linalg.vector_norm(v0_flat)
-        v0_flat /= length
-
-        def matvec_flat(v_flat, *p):
-            v = v_unflatten(v_flat)
-            Av = matvec(v, *p)
-            flat, unflatten = tree_util.ravel_pytree(Av)
-            return flat
-
-        algorithm = alg_tridiag_full_reortho(matvec_flat, order)
-        _, (diag, off_diag) = algorithm(v0_flat, *parameters)
-        eigvals, eigvecs = _eigh_tridiag(diag, off_diag)
-
-        # Since Q orthogonal (orthonormal) to v0, Q v = Q[0],
-        # and therefore (Q v)^T f(D) (Qv) = Q[0] * f(diag) * Q[0]
-        fx_eigvals = func.vmap(matfun)(eigvals)
-        return length**2 * linalg.vecdot(eigvecs[0, :], fx_eigvals * eigvecs[0, :])
-
-    return quadform
-
-
-def integrand_product_logdet(depth, matvec, vecmat, /):
-    r"""Construct the integrand for the log-determinant of a matrix-product.
-
-    Here, "product" refers to $X = A^\top A$.
-    """
-    return integrand_product(np.log, depth, matvec, vecmat)
-
-
-def integrand_product_schatten_norm(power, depth, matvec, vecmat, /):
-    r"""Construct the integrand for the p-th power of the Schatten-p norm."""
-
-    def matfun(x):
-        """Matrix-function for Schatten-p norms."""
-        return x ** (power / 2)
-
-    return integrand_product(matfun, depth, matvec, vecmat)
-
-
-def integrand_product(matfun, depth, matvec, vecmat, /):
-    r"""Construct the integrand for the trace of a function of a matrix-product.
-
-    Instead of the trace of a function of a matrix,
-    compute the trace of a function of the product of matrices.
-    Here, "product" refers to $X = A^\top A$.
-    """
-
-    def quadform(v0, *parameters):
-        v0_flat, v_unflatten = tree_util.ravel_pytree(v0)
-        length = linalg.vector_norm(v0_flat)
-        v0_flat /= length
-
-        def matvec_flat(v_flat, *p):
-            v = v_unflatten(v_flat)
-            Av = matvec(v, *p)
-            flat, unflatten = tree_util.ravel_pytree(Av)
-            return flat, tree_util.partial_pytree(unflatten)
-
-        w0_flat, w_unflatten = func.eval_shape(matvec_flat, v0_flat)
-        matrix_shape = (*np.shape(w0_flat), *np.shape(v0_flat))
-
-        def vecmat_flat(w_flat):
-            w = w_unflatten(w_flat)
-            wA = vecmat(w, *parameters)
-            return tree_util.ravel_pytree(wA)[0]
-
-        # Decompose into orthogonal-bidiag-orthogonal
-        algorithm = alg_bidiag_full_reortho(
-            lambda v: matvec_flat(v)[0], vecmat_flat, depth, matrix_shape=matrix_shape
-        )
-        output = algorithm(v0_flat, *parameters)
-        u, (d, e), vt, _ = output
-
-        # Compute SVD of factorisation
-        B = _bidiagonal_dense(d, e)
-        _, S, Vt = linalg.svd(B, full_matrices=False)
-
-        # Since Q orthogonal (orthonormal) to v0, Q v = Q[0],
-        # and therefore (Q v)^T f(D) (Qv) = Q[0] * f(diag) * Q[0]
-        eigvals, eigvecs = S**2, Vt.T
-        fx_eigvals = func.vmap(matfun)(eigvals)
-        return length**2 * linalg.vecdot(eigvecs[0, :], fx_eigvals * eigvecs[0, :])
-
-    return quadform
-
-
-def _bidiagonal_dense(d, e):
-    diag = linalg.diagonal_matrix(d)
-    offdiag = linalg.diagonal_matrix(e, 1)
-    return diag + offdiag
-
-
-def funm_vector_product_spd(matfun, order, matvec, /):
-    """Implement a matrix-function-vector product via Lanczos' algorithm.
-
-    This algorithm uses Lanczos' tridiagonalisation with full re-orthogonalisation
-    and therefore applies only to symmetric, positive definite matrices.
-    """
-    algorithm = alg_tridiag_full_reortho(matvec, order)
-
-    def estimate(vec, *parameters):
-        length = linalg.vector_norm(vec)
-        vec /= length
-        basis, (diag, off_diag) = algorithm(vec, *parameters)
-        eigvals, eigvecs = _eigh_tridiag(diag, off_diag)
-
-        fx_eigvals = func.vmap(matfun)(eigvals)
-        return length * (basis.T @ (eigvecs @ (fx_eigvals * eigvecs[0, :])))
-
-    return estimate
-
-
-def _eigh_tridiag(diag, off_diag):
-    # todo: once jax supports eigh_tridiagonal(eigvals_only=False),
-    #  use it here. Until then: an eigen-decomposition of size (order + 1)
-    #  does not hurt too much...
-    diag = linalg.diagonal_matrix(diag)
-    offdiag1 = linalg.diagonal_matrix(off_diag, -1)
-    offdiag2 = linalg.diagonal_matrix(off_diag, 1)
-    dense_matrix = diag + offdiag1 + offdiag2
-    eigvals, eigvecs = linalg.eigh(dense_matrix)
-    return eigvals, eigvecs
 
 
 def svd_approx(
@@ -410,3 +270,21 @@ def _decompose_fori_loop(v0, *parameters, algorithm: _LanczosAlg):
 
     result = control_flow.fori_loop(lower, upper, body_fun=body_fun, init_val=init_val)
     return extract(result)
+
+
+def _bidiagonal_dense(d, e):
+    diag = linalg.diagonal_matrix(d)
+    offdiag = linalg.diagonal_matrix(e, 1)
+    return diag + offdiag
+
+
+def _eigh_tridiag(diag, off_diag):
+    # todo: once jax supports eigh_tridiagonal(eigvals_only=False),
+    #  use it here. Until then: an eigen-decomposition of size (order + 1)
+    #  does not hurt too much...
+    diag = linalg.diagonal_matrix(diag)
+    offdiag1 = linalg.diagonal_matrix(off_diag, -1)
+    offdiag2 = linalg.diagonal_matrix(off_diag, 1)
+    dense_matrix = diag + offdiag1 + offdiag2
+    eigvals, eigvecs = linalg.eigh(dense_matrix)
+    return eigvals, eigvecs

--- a/matfree/lanczos.py
+++ b/matfree/lanczos.py
@@ -1,27 +1,12 @@
-"""All things Lanczos' algorithm.
+"""Lanczos-style matrix decompositions.
 
-This includes
-stochastic Lanczos quadrature (extending the integrands
-in [hutchinson][matfree.hutchinson] to those that implement
-stochastic Lanczos quadrature),
-Lanczos-implementations of matrix-function-vector products,
-and various Lanczos-decompositions of matrices.
+This module includes various Lanczos-decompositions of matrices
+(tridiagonalisation, bidiagonalisation, etc.).
 
-Examples
---------
->>> import jax.random
->>> import jax.numpy as jnp
->>>
->>> jnp.set_printoptions(1)
->>>
->>> M = jax.random.normal(jax.random.PRNGKey(1), shape=(10, 10))
->>> A = M.T @ M
->>> v = jax.random.normal(jax.random.PRNGKey(2), shape=(10,))
->>>
->>> # Compute a matrix-logarithm with Lanczos' algorithm
->>> matfun_vec = funm_vector_product_spd(jnp.log, 4, lambda s: A @ s)
->>> matfun_vec(v)
-Array([-4. , -2.1, -2.7, -1.9, -1.3, -3.5, -0.5, -0.1,  0.3,  1.5],      dtype=float32)
+For stochastic Lanczos quadrature, see
+[matfree.funm_trace][matfree.funm_trace].
+For matrix-function-vector products, see
+[matfree.funm][matfree.funm].
 """
 
 from matfree.backend import containers, control_flow, func, linalg, np

--- a/tests/test_funm/test_funm_chebyshev.py
+++ b/tests/test_funm/test_funm_chebyshev.py
@@ -1,10 +1,10 @@
 """Test matrix-polynomial-vector algorithms via Chebyshev's recursion."""
 
-from matfree import polynomial, test_util
+from matfree import funm, test_util
 from matfree.backend import linalg, np, prng
 
 
-def test_funm_vector_product_chebyshev(n=12):
+def test_funm_chebyshev(n=12):
     """Test matrix-polynomial-vector algorithms via Chebyshev's recursion."""
     # Create a test-problem: matvec, matrix function,
     # vector, and parameters (a matrix).
@@ -27,7 +27,7 @@ def test_funm_vector_product_chebyshev(n=12):
 
     # Create an implementation of the Chebyshev-algorithm
     order = 6
-    matfun_vec = polynomial.funm_vector_product_chebyshev(fun, order, matvec)
+    matfun_vec = funm.funm_chebyshev(fun, order, matvec)
 
     # Compute the matrix-function vector product
     received = matfun_vec(v, matrix)

--- a/tests/test_funm/test_funm_lanczos_spd.py
+++ b/tests/test_funm/test_funm_lanczos_spd.py
@@ -1,10 +1,10 @@
 """Test matrix-function-vector products via Lanczos' algorithm."""
 
-from matfree import lanczos, test_util
+from matfree import funm, test_util
 from matfree.backend import linalg, np, prng
 
 
-def test_funm_vector_product(n=11):
+def test_funm_lanczos_spd(n=11):
     """Test matrix-function-vector products via Lanczos' algorithm."""
     # Create a test-problem: matvec, matrix function,
     # vector, and parameters (a matrix).
@@ -12,8 +12,6 @@ def test_funm_vector_product(n=11):
     def matvec(x, p):
         return p @ x
 
-    # todo: write a test for matfun=np.inv,
-    #  because this application seems to be brittle
     def fun(x):
         return np.sin(x)
 
@@ -29,6 +27,6 @@ def test_funm_vector_product(n=11):
 
     # Compute the matrix-function vector product
     order = 6
-    matfun_vec = lanczos.funm_vector_product_spd(fun, order, matvec)
+    matfun_vec = funm.funm_lanczos_spd(fun, order, matvec)
     received = matfun_vec(v, matrix)
     assert np.allclose(expected, received, atol=1e-6)

--- a/tests/test_funm_trace/test_integrand_logdet_product.py
+++ b/tests/test_funm_trace/test_integrand_logdet_product.py
@@ -1,6 +1,6 @@
 """Test stochastic Lanczos quadrature for log-determinants of matrix-products."""
 
-from matfree import hutchinson, lanczos, test_util
+from matfree import funm_trace, hutchinson, test_util
 from matfree.backend import linalg, np, prng, testing
 
 
@@ -31,7 +31,7 @@ def test_logdet_product(A, order):
 
     x_like = {"fx": np.ones((ncols,), dtype=float)}
     fun = hutchinson.sampler_normal(x_like, num=400)
-    problem = lanczos.integrand_product_logdet(order, matvec, vecmat)
+    problem = funm_trace.integrand_product_logdet(order, matvec, vecmat)
     estimate = hutchinson.hutchinson(problem, fun)
     received = estimate(key)
 
@@ -53,7 +53,7 @@ def test_logdet_product_exact_for_full_order_lanczos(n):
 
     # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
     order = n - 1
-    integrand = lanczos.integrand_product_logdet(
+    integrand = funm_trace.integrand_product_logdet(
         order, lambda v: A @ v, lambda v: v @ A
     )
 

--- a/tests/test_funm_trace/test_integrand_logdet_spd.py
+++ b/tests/test_funm_trace/test_integrand_logdet_spd.py
@@ -1,6 +1,6 @@
 """Tests for Lanczos functionality."""
 
-from matfree import hutchinson, lanczos, test_util
+from matfree import funm_trace, hutchinson, test_util
 from matfree.backend import linalg, np, prng, testing
 
 
@@ -29,7 +29,7 @@ def test_logdet_spd(A, order):
     key = prng.prng_key(1)
     args_like = {"fx": np.ones((n,), dtype=float)}
     sampler = hutchinson.sampler_normal(args_like, num=10)
-    integrand = lanczos.integrand_spd_logdet(order, matvec)
+    integrand = funm_trace.integrand_spd_logdet(order, matvec)
     estimate = hutchinson.hutchinson(integrand, sampler)
     received = estimate(key)
 
@@ -49,7 +49,7 @@ def test_logdet_spd_exact_for_full_order_lanczos(n):
 
     # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
     order = n - 1
-    integrand = lanczos.integrand_spd_logdet(order, lambda v: A @ v)
+    integrand = funm_trace.integrand_spd_logdet(order, lambda v: A @ v)
 
     # Construct a vector without that does not have expected 2-norm equal to "dim"
     x = prng.normal(prng.prng_key(seed=1), shape=(n,)) + 10

--- a/tests/test_funm_trace/test_integrand_schatten_norm.py
+++ b/tests/test_funm_trace/test_integrand_schatten_norm.py
@@ -1,6 +1,6 @@
 """Test stochastic Lanczos quadrature for Schatten-p-norms."""
 
-from matfree import hutchinson, lanczos, test_util
+from matfree import funm_trace, hutchinson, test_util
 from matfree.backend import linalg, np, prng, testing
 
 
@@ -27,7 +27,7 @@ def test_schatten_norm(A, order, power):
     _, ncols = np.shape(A)
     args_like = np.ones((ncols,), dtype=float)
     sampler = hutchinson.sampler_normal(args_like, num=500)
-    integrand = lanczos.integrand_product_schatten_norm(
+    integrand = funm_trace.integrand_product_schatten_norm(
         power, order, lambda v: A @ v, lambda v: A.T @ v
     )
     estimate = hutchinson.hutchinson(integrand, sampler)

--- a/tutorials/1_log_determinants.py
+++ b/tutorials/1_log_determinants.py
@@ -7,7 +7,7 @@ which can be loosely interpreted as an extension of Hutchinson's trace estimator
 import jax
 import jax.numpy as jnp
 
-from matfree import hutchinson, lanczos
+from matfree import funm_trace, hutchinson
 
 # Set up a matrix.
 
@@ -27,7 +27,7 @@ x_like = jnp.ones((nrows,), dtype=float)  # use to determine shapes of vectors
 # Estimate log-determinants with stochastic Lanczos quadrature.
 
 order = 3
-problem = lanczos.integrand_spd_logdet(order, matvec)
+problem = funm_trace.integrand_spd_logdet(order, matvec)
 sampler = hutchinson.sampler_normal(x_like, num=1_000)
 estimator = hutchinson.hutchinson(problem, sample_fun=sampler)
 logdet = estimator(jax.random.PRNGKey(1))
@@ -58,7 +58,7 @@ def vecmat_left(x):
 
 
 order = 3
-problem = lanczos.integrand_product_logdet(order, matvec_right, vecmat_left)
+problem = funm_trace.integrand_product_logdet(order, matvec_right, vecmat_left)
 sampler = hutchinson.sampler_normal(x_like, num=1_000)
 estimator = hutchinson.hutchinson(problem, sample_fun=sampler)
 logdet = estimator(jax.random.PRNGKey(1))

--- a/tutorials/2_pytree_logdeterminants.py
+++ b/tutorials/2_pytree_logdeterminants.py
@@ -8,7 +8,7 @@ Yes, we can. Matfree natively supports PyTrees.
 import jax
 import jax.numpy as jnp
 
-from matfree import hutchinson, lanczos
+from matfree import funm_trace, hutchinson
 
 # Create a test-problem: a function that maps a pytree (dict) to a pytree (tuple).
 # Its (regularised) Gauss--Newton Hessian shall be the matrix-vector product
@@ -53,7 +53,7 @@ def make_matvec(alpha):
 
 matvec = make_matvec(alpha=0.1)
 order = 3
-integrand = lanczos.integrand_spd_logdet(order, matvec)
+integrand = funm_trace.integrand_spd_logdet(order, matvec)
 sample_fun = hutchinson.sampler_normal(f0, num=10)
 estimator = hutchinson.hutchinson(integrand, sample_fun=sample_fun)
 key = jax.random.PRNGKey(1)


### PR DESCRIPTION
This PR moves all f(A)v and trace(f(A)) code to separate modules.
This deletes matfree.polynomial and clears much of matfree.lanczos.

The motivation is that we want to have functions that yield similar results in the same module (instead of functions that use similar algorithms behind the scenes). We also want to trim down the Lanczos module a bit, because more code is coming  there :eyes:  