### PR TITLE
Rename misnamed functions

### DIFF
--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -20,10 +20,10 @@ Array([-4. , -2.1, -2.7, -1.9, -1.3, -3.5, -0.5, -0.1,  0.3,  1.5],      dtype=f
 
 from matfree import lanczos
 from matfree.backend import containers, control_flow, func, linalg, np
-from matfree.backend.typing import Array
+from matfree.backend.typing import Array, Callable
 
 
-def funm_chebyshev(matfun, order, matvec, /):
+def funm_chebyshev(matfun: Callable, order: int, matvec: Callable, /) -> Callable:
     """Compute a matrix-function-vector product via Chebyshev's algorithm.
 
     This function assumes that the **spectrum of the matrix-vector product
@@ -98,8 +98,8 @@ def _funm_polyexpand(matrix_poly_alg, /):
 # todo: "spd" -> "sym"
 
 
-def funm_lanczos_spd(matfun, order, matvec, /):
-    """Implement a matrix-function-vector product via Lanczos' algorithm.
+def funm_lanczos_sym(matfun: Callable, order: int, matvec: Callable, /) -> Callable:
+    """Implement a matrix-function-vector product via Lanczos' tridiagonalisation.
 
     This algorithm uses Lanczos' tridiagonalisation
     and therefore applies only to symmetric matrices.

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -13,7 +13,7 @@ Examples
 >>> v = jax.random.normal(jax.random.PRNGKey(2), shape=(10,))
 >>>
 >>> # Compute a matrix-logarithm with Lanczos' algorithm
->>> matfun_vec = funm_lanczos_spd(jnp.log, 4, lambda s: A @ s)
+>>> matfun_vec = funm_lanczos_sym(jnp.log, 4, lambda s: A @ s)
 >>> matfun_vec(v)
 Array([-4. , -2.1, -2.7, -1.9, -1.3, -3.5, -0.5, -0.1,  0.3,  1.5],      dtype=float32)
 """

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -80,7 +80,7 @@ def _chebyshev_nodes(n, /):
 
 
 def _funm_polyexpand(matrix_poly_alg, /):
-    """Implement a matrix-function-vector product via a polynomial expansion."""
+    """Compute a matrix-function-vector product via a polynomial expansion."""
     (lower, upper), init_func, step_func, extract_func = matrix_poly_alg
 
     def matvec(vec, *parameters):
@@ -95,11 +95,14 @@ def _funm_polyexpand(matrix_poly_alg, /):
     return matvec
 
 
+# todo: "spd" -> "sym"
+
+
 def funm_lanczos_spd(matfun, order, matvec, /):
     """Implement a matrix-function-vector product via Lanczos' algorithm.
 
-    This algorithm uses Lanczos' tridiagonalisation with full re-orthogonalisation
-    and therefore applies only to symmetric, positive definite matrices.
+    This algorithm uses Lanczos' tridiagonalisation
+    and therefore applies only to symmetric matrices.
     """
     algorithm = lanczos.alg_tridiag_full_reortho(matvec, order)
 

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -95,9 +95,6 @@ def _funm_polyexpand(matrix_poly_alg, /):
     return matvec
 
 
-# todo: "spd" -> "sym"
-
-
 def funm_lanczos_sym(matfun: Callable, order: int, matvec: Callable, /) -> Callable:
     """Implement a matrix-function-vector product via Lanczos' tridiagonalisation.
 

--- a/matfree/funm_trace.py
+++ b/matfree/funm_trace.py
@@ -12,18 +12,18 @@ from matfree.backend import func, linalg, np, tree_util
 #  something else.
 
 
-def integrand_spd_logdet(order, matvec, /):
+def integrand_sym_logdet(order, matvec, /):
     """Construct the integrand for the log-determinant.
 
     This function assumes a symmetric, positive definite matrix.
     """
-    return integrand_spd(np.log, order, matvec)
+    return integrand_sym(np.log, order, matvec)
 
 
-def integrand_spd(matfun, order, matvec, /):
-    """Quadratic form for stochastic Lanczos quadrature.
+def integrand_sym(matfun, order, matvec, /):
+    """Construct the integrand for matrix-function-trace estimation.
 
-    This function assumes a symmetric, positive definite matrix.
+    This function assumes a symmetric matrix.
     """
 
     def quadform(v0, *parameters):
@@ -68,7 +68,7 @@ def integrand_product_schatten_norm(power, depth, matvec, vecmat, /):
 
 
 def integrand_product(matfun, depth, matvec, vecmat, /):
-    r"""Construct the integrand for the trace of a function of a matrix-product.
+    """Construct the integrand for matrix-function-trace estimation.
 
     Instead of the trace of a function of a matrix,
     compute the trace of a function of the product of matrices.

--- a/matfree/hutchinson.py
+++ b/matfree/hutchinson.py
@@ -2,6 +2,10 @@
 
 from matfree.backend import func, linalg, np, prng, tree_util
 
+# todo: rename this module. Why? Because
+#  stochastic trace estimation should not be tied that closely to Hutchinson's name,
+#  since others have influenced it massively, too.
+
 
 def hutchinson(integrand_fun, /, sample_fun):
     """Construct Hutchinson's estimator.

--- a/matfree/lanczos.py
+++ b/matfree/lanczos.py
@@ -12,6 +12,13 @@ For matrix-function-vector products, see
 from matfree.backend import containers, control_flow, func, linalg, np
 from matfree.backend.typing import Array, Callable, Tuple
 
+# todo: rename this module, because we may easily include arnoldi here, too.
+#  what do we rename it to? krylov.py? decomp.py? krylovbasis.py?
+
+
+# todo: rename svd_approx to svd_partial() because the algorithm is called
+#  "Partial SVD", not "Approximate SVD".
+
 
 def svd_approx(
     v0: Array, depth: int, Av: Callable, vA: Callable, matrix_shape: Tuple[int, ...]

--- a/tests/test_funm/test_funm_lanczos_sym.py
+++ b/tests/test_funm/test_funm_lanczos_sym.py
@@ -4,7 +4,7 @@ from matfree import funm, test_util
 from matfree.backend import linalg, np, prng
 
 
-def test_funm_lanczos_spd(n=11):
+def test_funm_lanczos_sym(n=11):
     """Test matrix-function-vector products via Lanczos' algorithm."""
     # Create a test-problem: matvec, matrix function,
     # vector, and parameters (a matrix).
@@ -27,6 +27,6 @@ def test_funm_lanczos_spd(n=11):
 
     # Compute the matrix-function vector product
     order = 6
-    matfun_vec = funm.funm_lanczos_spd(fun, order, matvec)
+    matfun_vec = funm.funm_lanczos_sym(fun, order, matvec)
     received = matfun_vec(v, matrix)
     assert np.allclose(expected, received, atol=1e-6)

--- a/tests/test_funm_trace/test_integrand_logdet_sym.py
+++ b/tests/test_funm_trace/test_integrand_logdet_sym.py
@@ -19,7 +19,7 @@ def A(n, num_significant_eigvals):
 @testing.parametrize("order", [10])
 # usually: ~1.5 * num_significant_eigvals.
 # But logdet seems to converge sooo much faster.
-def test_logdet_spd(A, order):
+def test_logdet_sym(A, order):
     """Assert that the log-determinant estimation matches the true log-determinant."""
     n, _ = np.shape(A)
 
@@ -29,7 +29,7 @@ def test_logdet_spd(A, order):
     key = prng.prng_key(1)
     args_like = {"fx": np.ones((n,), dtype=float)}
     sampler = hutchinson.sampler_normal(args_like, num=10)
-    integrand = funm_trace.integrand_spd_logdet(order, matvec)
+    integrand = funm_trace.integrand_sym_logdet(order, matvec)
     estimate = hutchinson.hutchinson(integrand, sampler)
     received = estimate(key)
 
@@ -41,7 +41,7 @@ def test_logdet_spd(A, order):
 @testing.parametrize("n", [50])
 # usually: ~1.5 * num_significant_eigvals.
 # But logdet seems to converge sooo much faster.
-def test_logdet_spd_exact_for_full_order_lanczos(n):
+def test_logdet_sym_exact_for_full_order_lanczos(n):
     r"""Computing v^\top f(A) v with max-order Lanczos should be exact for _any_ v."""
     # Construct a (numerically nice) matrix
     eigvals = np.arange(1.0, 1.0 + n, step=1.0)
@@ -49,7 +49,7 @@ def test_logdet_spd_exact_for_full_order_lanczos(n):
 
     # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
     order = n - 1
-    integrand = funm_trace.integrand_spd_logdet(order, lambda v: A @ v)
+    integrand = funm_trace.integrand_sym_logdet(order, lambda v: A @ v)
 
     # Construct a vector without that does not have expected 2-norm equal to "dim"
     x = prng.normal(prng.prng_key(seed=1), shape=(n,)) + 10

--- a/tests/test_funm_trace/test_integrand_logdet_sym.py
+++ b/tests/test_funm_trace/test_integrand_logdet_sym.py
@@ -19,7 +19,7 @@ def A(n, num_significant_eigvals):
 @testing.parametrize("order", [10])
 # usually: ~1.5 * num_significant_eigvals.
 # But logdet seems to converge sooo much faster.
-def test_logdet_sym(A, order):
+def test_logdet_spd(A, order):
     """Assert that the log-determinant estimation matches the true log-determinant."""
     n, _ = np.shape(A)
 
@@ -41,7 +41,7 @@ def test_logdet_sym(A, order):
 @testing.parametrize("n", [50])
 # usually: ~1.5 * num_significant_eigvals.
 # But logdet seems to converge sooo much faster.
-def test_logdet_sym_exact_for_full_order_lanczos(n):
+def test_logdet_spd_exact_for_full_order_lanczos(n):
     r"""Computing v^\top f(A) v with max-order Lanczos should be exact for _any_ v."""
     # Construct a (numerically nice) matrix
     eigvals = np.arange(1.0, 1.0 + n, step=1.0)

--- a/tutorials/1_log_determinants.py
+++ b/tutorials/1_log_determinants.py
@@ -27,7 +27,7 @@ x_like = jnp.ones((nrows,), dtype=float)  # use to determine shapes of vectors
 # Estimate log-determinants with stochastic Lanczos quadrature.
 
 order = 3
-problem = funm_trace.integrand_spd_logdet(order, matvec)
+problem = funm_trace.integrand_sym_logdet(order, matvec)
 sampler = hutchinson.sampler_normal(x_like, num=1_000)
 estimator = hutchinson.hutchinson(problem, sample_fun=sampler)
 logdet = estimator(jax.random.PRNGKey(1))

--- a/tutorials/2_pytree_logdeterminants.py
+++ b/tutorials/2_pytree_logdeterminants.py
@@ -53,7 +53,7 @@ def make_matvec(alpha):
 
 matvec = make_matvec(alpha=0.1)
 order = 3
-integrand = funm_trace.integrand_spd_logdet(order, matvec)
+integrand = funm_trace.integrand_sym_logdet(order, matvec)
 sample_fun = hutchinson.sampler_normal(f0, num=10)
 estimator = hutchinson.hutchinson(integrand, sample_fun=sample_fun)
 key = jax.random.PRNGKey(1)


### PR DESCRIPTION
Many Lanczos-tridiagonalisation functions came with the `spd` suffix, but those functions only require symmetric matrices, not symmetric positive definite matrices.
