### PR TITLE
Implement differentiable Lanczos and Arnoldi iterations

### DIFF
--- a/matfree/backend/config.py
+++ b/matfree/backend/config.py
@@ -1,0 +1,7 @@
+"""Configuration."""
+
+import jax
+
+
+def update(what, how, /):
+    jax.config.update(what, how)

--- a/matfree/backend/func.py
+++ b/matfree/backend/func.py
@@ -42,6 +42,14 @@ def vjp(func, /, *primals):
     return jax.vjp(func, *primals)
 
 
+def custom_vjp(func, /, nondiff_argnums=()):
+    return jax.custom_vjp(func, nondiff_argnums=nondiff_argnums)
+
+
+def closure_convert(func, *args):
+    return jax.closure_convert(func, *args)
+
+
 # Inferring input and output shapes:
 
 

--- a/matfree/backend/np.py
+++ b/matfree/backend/np.py
@@ -191,3 +191,7 @@ def convolve(a, b, /, mode="full"):
 
 def tril(x, /, shift=0):
     return jnp.tril(x, shift)
+
+
+def triu(x, /, shift=0):
+    return jnp.triu(x, shift)

--- a/matfree/backend/np.py
+++ b/matfree/backend/np.py
@@ -187,3 +187,7 @@ def finfo_eps(x, /):
 
 def convolve(a, b, /, mode="full"):
     return jnp.convolve(a, b, mode=mode)
+
+
+def tril(x, /, shift=0):
+    return jnp.tril(x, shift)

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -123,5 +123,6 @@ def _eigh_tridiag_sym(diag, off_diag):
     offdiag1 = linalg.diagonal_matrix(off_diag, -1)
     offdiag2 = linalg.diagonal_matrix(off_diag, 1)
     dense_matrix = diag + offdiag1 + offdiag2
+
     eigvals, eigvecs = linalg.eigh(dense_matrix)
     return eigvals, eigvecs

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -15,7 +15,7 @@ Examples
 >>> # Compute a matrix-logarithm with Lanczos' algorithm
 >>> matfun_vec = funm_lanczos_sym(jnp.log, 4, lambda s: A @ s)
 >>> matfun_vec(v)
-Array([-4. , -2.1, -2.7, -1.9, -1.3, -3.5, -0.5, -0.1,  0.3,  1.5],      dtype=float32)
+Array([-4.1, -1.3, -2.2, -2.1, -1.2, -3.3, -0.2,  0.3,  0.7,  0.9],      dtype=float32)
 """
 
 from matfree import decomp
@@ -95,6 +95,8 @@ def _funm_polyexpand(matrix_poly_alg, /):
     return matvec
 
 
+# todo: if we pass decomp.tridiag_sym instead of order & matvec,
+#  the user gets more control over questions like reorthogonalisation
 def funm_lanczos_sym(matfun: Callable, order: int, matvec: Callable, /) -> Callable:
     """Implement a matrix-function-vector product via Lanczos' tridiagonalisation.
 
@@ -106,7 +108,7 @@ def funm_lanczos_sym(matfun: Callable, order: int, matvec: Callable, /) -> Calla
     def estimate(vec, *parameters):
         length = linalg.vector_norm(vec)
         vec /= length
-        basis, (diag, off_diag) = algorithm(vec, *parameters)
+        (basis, (diag, off_diag)), _ = algorithm(vec, *parameters)
         eigvals, eigvecs = _eigh_tridiag_sym(diag, off_diag)
 
         fx_eigvals = func.vmap(matfun)(eigvals)

--- a/matfree/stochtrace_funm.py
+++ b/matfree/stochtrace_funm.py
@@ -38,7 +38,7 @@ def integrand_sym(matfun, order, matvec, /):
             return flat
 
         algorithm = decomp.tridiag_sym(matvec_flat, order)
-        _, (diag, off_diag) = algorithm(v0_flat, *parameters)
+        (_, (diag, off_diag)), _ = algorithm(v0_flat, *parameters)
         eigvals, eigvecs = _eigh_tridiag_sym(diag, off_diag)
 
         # Since Q orthogonal (orthonormal) to v0, Q v = Q[0],

--- a/matfree/test_util.py
+++ b/matfree/test_util.py
@@ -1,6 +1,6 @@
 """Test utilities."""
 
-from matfree.backend import linalg, np
+from matfree.backend import linalg, np, prng, tree_util
 
 
 def symmetric_matrix_from_eigenvalues(eigvals, /):
@@ -41,3 +41,9 @@ def to_dense_tridiag_sym(d, e, /):
     offdiag1 = linalg.diagonal_matrix(e, offset=1)
     offdiag2 = linalg.diagonal_matrix(e, offset=-1)
     return diag + offdiag1 + offdiag2
+
+
+def tree_random_like(key, tree, *, generate_func=prng.normal):
+    flat, unflatten = tree_util.ravel_pytree(tree)
+    flat_like = generate_func(key, shape=flat.shape, dtype=flat.dtype)
+    return unflatten(flat_like)

--- a/tests/test_decomp/test_hessenberg_adjoint.py
+++ b/tests/test_decomp/test_hessenberg_adjoint.py
@@ -1,23 +1,17 @@
-import jax
-import jax.flatten_util
-import jax.numpy as jnp
-import pytest
-import pytest_cases
-
 from matfree import decomp, test_util
-from matfree.backend import linalg
+from matfree.backend import config, func, linalg, np, prng, testing
 
 
-@pytest_cases.parametrize("nrows", [3])
-@pytest_cases.parametrize("krylov_depth", [2])
-@pytest_cases.parametrize("reortho", ["none", "full"])
-@pytest_cases.parametrize("dtype", [float])
+@testing.parametrize("nrows", [3])
+@testing.parametrize("krylov_depth", [2])
+@testing.parametrize("reortho", ["none", "full"])
+@testing.parametrize("dtype", [float])
 def test_adjoint_matches_jax_dot_vjp(nrows, krylov_depth, reortho, dtype):
     # todo: see which components simplify for symmetric matrices
 
     # Create a matrix and a direction as a test-case
-    A = jax.random.normal(jax.random.PRNGKey(1), shape=(nrows, nrows), dtype=dtype)
-    v = jax.random.normal(jax.random.PRNGKey(2), shape=(nrows,), dtype=dtype)
+    A = prng.normal(prng.prng_key(1), shape=(nrows, nrows), dtype=dtype)
+    v = prng.normal(prng.prng_key(2), shape=(nrows,), dtype=dtype)
 
     # Set up the algorithms
     algorithm_autodiff = decomp.hessenberg(
@@ -28,40 +22,40 @@ def test_adjoint_matches_jax_dot_vjp(nrows, krylov_depth, reortho, dtype):
     )
 
     # Forward pass
-    (Q, H, r, c), vjp_autodiff = jax.vjp(algorithm_autodiff, v, A)
-    (_Q, _H, _r, _c), vjp_adjoint = jax.vjp(algorithm_adjoint, v, A)
+    (Q, H, r, c), vjp_autodiff = func.vjp(algorithm_autodiff, v, A)
+    (_Q, _H, _r, _c), vjp_adjoint = func.vjp(algorithm_adjoint, v, A)
 
     # Random input gradients (no sparsity at all)
-    (dQ, dH, dr, dc) = test_util.tree_random_like(jax.random.PRNGKey(3), (Q, H, r, c))
+    (dQ, dH, dr, dc) = test_util.tree_random_like(prng.prng_key(3), (Q, H, r, c))
 
     # Call the auto-diff VJP
     dv_autodiff, dp_autodiff = vjp_autodiff((dQ, dH, dr, dc))
     dv_adjoint, dp_adjoint = vjp_adjoint((dQ, dH, dr, dc))
 
     # Tie the tolerance to the floating-point accuracy
-    small_value = 10 * jnp.sqrt(jnp.finfo(jnp.dtype(H)).eps)
+    small_value = 10 * np.sqrt(np.finfo_eps(np.dtype(H)))
     tols = {"atol": small_value, "rtol": small_value}
 
     # Assert gradients match
-    assert jnp.allclose(dv_adjoint, dv_autodiff, **tols)
-    assert jnp.allclose(dp_adjoint, dp_autodiff, **tols)
+    assert np.allclose(dv_adjoint, dv_autodiff, **tols)
+    assert np.allclose(dp_adjoint, dp_autodiff, **tols)
 
     # Assert that the values are only similar, not identical
-    assert not jnp.all(dv_adjoint == dv_autodiff)
-    assert not jnp.all(dp_adjoint == dp_autodiff)
+    assert not np.all(dv_adjoint == dv_autodiff)
+    assert not np.all(dp_adjoint == dp_autodiff)
 
 
-@pytest_cases.parametrize("nrows", [15])
-@pytest_cases.parametrize("krylov_depth", [10])
-@pytest_cases.parametrize("reortho", ["full"])
+@testing.parametrize("nrows", [15])
+@testing.parametrize("krylov_depth", [10])
+@testing.parametrize("reortho", ["full"])
 def test_adjoint_matches_jax_dot_vjp_hilbert_matrix_and_full_reortho(
     nrows, krylov_depth, reortho
 ):
-    jax.config.update("jax_enable_x64", True)
+    config.update("jax_enable_x64", True)
 
     # Create a matrix and a direction as a test-case
     A = _lower(linalg.hilbert(nrows))
-    v = jax.random.normal(jax.random.PRNGKey(2), shape=(nrows,), dtype=A.dtype)
+    v = prng.normal(prng.prng_key(2), shape=(nrows,), dtype=A.dtype)
 
     def matvec(s, p):
         return (p + p.T) @ s
@@ -75,40 +69,40 @@ def test_adjoint_matches_jax_dot_vjp_hilbert_matrix_and_full_reortho(
     )
 
     # Forward pass
-    (Q, H, r, c), vjp_autodiff = jax.vjp(algorithm_autodiff, v, A)
-    (_Q, _H, _r, _c), vjp_adjoint = jax.vjp(algorithm_adjoint, v, A)
+    (Q, H, r, c), vjp_autodiff = func.vjp(algorithm_autodiff, v, A)
+    (_Q, _H, _r, _c), vjp_adjoint = func.vjp(algorithm_adjoint, v, A)
 
     # Random input gradients (no sparsity at all)
-    (dQ, dH, dr, dc) = test_util.tree_random_like(jax.random.PRNGKey(3), (Q, H, r, c))
+    (dQ, dH, dr, dc) = test_util.tree_random_like(prng.prng_key(3), (Q, H, r, c))
 
     # Call the auto-diff VJP
     dv_autodiff, dp_autodiff = vjp_autodiff((dQ, dH, dr, dc))
     dv_adjoint, dp_adjoint = vjp_adjoint((dQ, dH, dr, dc))
 
     # Tie the tolerance to the floating-point accuracy
-    small_value = 10 * jnp.sqrt(jnp.finfo(jnp.dtype(H)).eps)
+    small_value = 10 * np.sqrt(np.finfo_eps(np.dtype(H)))
     tols = {"atol": small_value, "rtol": small_value}
 
     # Assert gradients match
-    assert jnp.allclose(dv_adjoint, dv_autodiff, **tols)
-    assert jnp.allclose(dp_adjoint, dp_autodiff, **tols)
+    assert np.allclose(dv_adjoint, dv_autodiff, **tols)
+    assert np.allclose(dp_adjoint, dp_autodiff, **tols)
 
     # Assert that the values are only similar, not identical
-    assert not jnp.all(dv_adjoint == dv_autodiff)
-    assert not jnp.all(dp_adjoint == dp_autodiff)
+    assert not np.all(dv_adjoint == dv_autodiff)
+    assert not np.all(dp_adjoint == dp_autodiff)
 
-    jax.config.update("jax_enable_x64", False)
+    config.update("jax_enable_x64", False)
 
 
 def _lower(m):
-    m_tril = jnp.tril(m)
+    m_tril = np.tril(m)
     return m_tril - 0.5 * linalg.diagonal_matrix(linalg.diagonal(m_tril))
 
 
-@pytest_cases.parametrize("reortho_wrong", [True, "full_with_sparsity", "None"])
+@testing.parametrize("reortho_wrong", [True, "full_with_sparsity", "None"])
 def test_raises_type_error_for_wrong_reorthogonalisation_flag(reortho_wrong):
     # Create a matrix and a direction as a test-case
 
     # Set up the algorithms
-    with pytest.raises(TypeError, match="Unexpected input"):
+    with testing.raises(TypeError, match="Unexpected input"):
         _ = decomp.hessenberg(lambda s: s, 1, reortho=reortho_wrong)

--- a/tests/test_decomp/test_hessenberg_adjoint.py
+++ b/tests/test_decomp/test_hessenberg_adjoint.py
@@ -1,0 +1,114 @@
+import jax
+import jax.flatten_util
+import jax.numpy as jnp
+import pytest
+import pytest_cases
+
+from matfree import decomp, test_util
+from matfree.backend import linalg
+
+
+@pytest_cases.parametrize("nrows", [3])
+@pytest_cases.parametrize("krylov_depth", [2])
+@pytest_cases.parametrize("reortho", ["none", "full"])
+@pytest_cases.parametrize("dtype", [float])
+def test_adjoint_matches_jax_dot_vjp(nrows, krylov_depth, reortho, dtype):
+    # todo: see which components simplify for symmetric matrices
+
+    # Create a matrix and a direction as a test-case
+    A = jax.random.normal(jax.random.PRNGKey(1), shape=(nrows, nrows), dtype=dtype)
+    v = jax.random.normal(jax.random.PRNGKey(2), shape=(nrows,), dtype=dtype)
+
+    # Set up the algorithms
+    algorithm_autodiff = decomp.hessenberg(
+        lambda s, p: p @ s, krylov_depth, reortho=reortho, custom_vjp=False
+    )
+    algorithm_adjoint = decomp.hessenberg(
+        lambda s, p: p @ s, krylov_depth, reortho=reortho, custom_vjp=True
+    )
+
+    # Forward pass
+    (Q, H, r, c), vjp_autodiff = jax.vjp(algorithm_autodiff, v, A)
+    (_Q, _H, _r, _c), vjp_adjoint = jax.vjp(algorithm_adjoint, v, A)
+
+    # Random input gradients (no sparsity at all)
+    (dQ, dH, dr, dc) = test_util.tree_random_like(jax.random.PRNGKey(3), (Q, H, r, c))
+
+    # Call the auto-diff VJP
+    dv_autodiff, dp_autodiff = vjp_autodiff((dQ, dH, dr, dc))
+    dv_adjoint, dp_adjoint = vjp_adjoint((dQ, dH, dr, dc))
+
+    # Tie the tolerance to the floating-point accuracy
+    small_value = 10 * jnp.sqrt(jnp.finfo(jnp.dtype(H)).eps)
+    tols = {"atol": small_value, "rtol": small_value}
+
+    # Assert gradients match
+    assert jnp.allclose(dv_adjoint, dv_autodiff, **tols)
+    assert jnp.allclose(dp_adjoint, dp_autodiff, **tols)
+
+    # Assert that the values are only similar, not identical
+    assert not jnp.all(dv_adjoint == dv_autodiff)
+    assert not jnp.all(dp_adjoint == dp_autodiff)
+
+
+@pytest_cases.parametrize("nrows", [15])
+@pytest_cases.parametrize("krylov_depth", [10])
+@pytest_cases.parametrize("reortho", ["full"])
+def test_adjoint_matches_jax_dot_vjp_hilbert_matrix_and_full_reortho(
+    nrows, krylov_depth, reortho
+):
+    jax.config.update("jax_enable_x64", True)
+
+    # Create a matrix and a direction as a test-case
+    A = _lower(linalg.hilbert(nrows))
+    v = jax.random.normal(jax.random.PRNGKey(2), shape=(nrows,), dtype=A.dtype)
+
+    def matvec(s, p):
+        return (p + p.T) @ s
+
+    # Set up the algorithms
+    algorithm_autodiff = decomp.hessenberg(
+        matvec, krylov_depth, reortho=reortho, custom_vjp=False
+    )
+    algorithm_adjoint = decomp.hessenberg(
+        matvec, krylov_depth, reortho=reortho, custom_vjp=True
+    )
+
+    # Forward pass
+    (Q, H, r, c), vjp_autodiff = jax.vjp(algorithm_autodiff, v, A)
+    (_Q, _H, _r, _c), vjp_adjoint = jax.vjp(algorithm_adjoint, v, A)
+
+    # Random input gradients (no sparsity at all)
+    (dQ, dH, dr, dc) = test_util.tree_random_like(jax.random.PRNGKey(3), (Q, H, r, c))
+
+    # Call the auto-diff VJP
+    dv_autodiff, dp_autodiff = vjp_autodiff((dQ, dH, dr, dc))
+    dv_adjoint, dp_adjoint = vjp_adjoint((dQ, dH, dr, dc))
+
+    # Tie the tolerance to the floating-point accuracy
+    small_value = 10 * jnp.sqrt(jnp.finfo(jnp.dtype(H)).eps)
+    tols = {"atol": small_value, "rtol": small_value}
+
+    # Assert gradients match
+    assert jnp.allclose(dv_adjoint, dv_autodiff, **tols)
+    assert jnp.allclose(dp_adjoint, dp_autodiff, **tols)
+
+    # Assert that the values are only similar, not identical
+    assert not jnp.all(dv_adjoint == dv_autodiff)
+    assert not jnp.all(dp_adjoint == dp_autodiff)
+
+    jax.config.update("jax_enable_x64", False)
+
+
+def _lower(m):
+    m_tril = jnp.tril(m)
+    return m_tril - 0.5 * linalg.diagonal_matrix(linalg.diagonal(m_tril))
+
+
+@pytest_cases.parametrize("reortho_wrong", [True, "full_with_sparsity", "None"])
+def test_raises_type_error_for_wrong_reorthogonalisation_flag(reortho_wrong):
+    # Create a matrix and a direction as a test-case
+
+    # Set up the algorithms
+    with pytest.raises(TypeError, match="Unexpected input"):
+        _ = decomp.hessenberg(lambda s: s, 1, reortho=reortho_wrong)

--- a/tests/test_decomp/test_tridiag_sym_adjoint.py
+++ b/tests/test_decomp/test_tridiag_sym_adjoint.py
@@ -1,19 +1,14 @@
 """Test the adjoint of tri-diagonalisation."""
 
-import functools
-
-import jax.flatten_util
-import jax.numpy as jnp
-import pytest_cases
-
 from matfree import decomp, test_util
+from matfree.backend import func, linalg, np, prng, testing, tree_util
 
 
-@pytest_cases.parametrize("reortho", ["full", "none"])
+@testing.parametrize("reortho", ["full", "none"])
 def test_adjoint_vjp_matches_jax_vjp(reortho, n=10, krylov_order=4):
     """Test that the custom VJP yields the same output as autodiff."""
     # Set up a test-matrix
-    eigvals = jax.random.uniform(jax.random.PRNGKey(2), shape=(n,)) + 1.0
+    eigvals = prng.uniform(prng.prng_key(2), shape=(n,)) + 1.0
     matrix = test_util.symmetric_matrix_from_eigenvalues(eigvals)
     params = _sym(matrix)
 
@@ -21,34 +16,34 @@ def test_adjoint_vjp_matches_jax_vjp(reortho, n=10, krylov_order=4):
         return (p + p.T) @ s
 
     # Set up an initial vector
-    vector = jax.random.normal(jax.random.PRNGKey(1), shape=(n,))
+    vector = prng.normal(prng.prng_key(1), shape=(n,))
 
     # Flatten the inputs
-    flat, unflatten = jax.flatten_util.ravel_pytree((vector, params))
+    flat, unflatten = tree_util.ravel_pytree((vector, params))
 
     # Construct a vector-to-vector decomposition function
     def decompose(f, *, custom_vjp):
         kwargs = {"reortho": reortho, "custom_vjp": custom_vjp}
         algorithm = decomp.tridiag_sym(matvec, krylov_order, **kwargs)
         output = algorithm(*unflatten(f))
-        return jax.flatten_util.ravel_pytree(output)[0]
+        return tree_util.ravel_pytree(output)[0]
 
     # Construct the two implementations
-    reference = jax.jit(functools.partial(decompose, custom_vjp=False))
-    implementation = jax.jit(functools.partial(decompose, custom_vjp=True))
+    reference = func.jit(func.partial(decompose, custom_vjp=False))
+    implementation = func.jit(func.partial(decompose, custom_vjp=True))
 
     # Compute both VJPs
-    fx_ref, vjp_ref = jax.vjp(reference, flat)
-    fx_imp, vjp_imp = jax.vjp(implementation, flat)
+    fx_ref, vjp_ref = func.vjp(reference, flat)
+    fx_imp, vjp_imp = func.vjp(implementation, flat)
     # Assert that the forward-passes are identical
-    assert jnp.allclose(fx_ref, fx_imp)
+    assert np.allclose(fx_ref, fx_imp)
 
     # Assert that the VJPs into a bunch of random directions are identical
     for seed in [4, 5, 6]:
-        key = jax.random.PRNGKey(seed)
-        dnu = jax.random.normal(key, shape=jnp.shape(reference(flat)))
-        assert jnp.allclose(*vjp_ref(dnu), *vjp_imp(dnu), atol=1e-4, rtol=1e-4)
+        key = prng.prng_key(seed)
+        dnu = prng.normal(key, shape=np.shape(reference(flat)))
+        assert np.allclose(*vjp_ref(dnu), *vjp_imp(dnu), atol=1e-4, rtol=1e-4)
 
 
 def _sym(m):
-    return jnp.triu(m) - jnp.diag(0.5 * jnp.diag(m))
+    return np.triu(m) - linalg.diagonal_matrix(0.5 * linalg.diagonal(m))

--- a/tests/test_decomp/test_tridiag_sym_adjoint.py
+++ b/tests/test_decomp/test_tridiag_sym_adjoint.py
@@ -1,0 +1,54 @@
+"""Test the adjoint of tri-diagonalisation."""
+
+import functools
+
+import jax.flatten_util
+import jax.numpy as jnp
+import pytest_cases
+
+from matfree import decomp, test_util
+
+
+@pytest_cases.parametrize("reortho", ["full", "none"])
+def test_adjoint_vjp_matches_jax_vjp(reortho, n=10, krylov_order=4):
+    """Test that the custom VJP yields the same output as autodiff."""
+    # Set up a test-matrix
+    eigvals = jax.random.uniform(jax.random.PRNGKey(2), shape=(n,)) + 1.0
+    matrix = test_util.symmetric_matrix_from_eigenvalues(eigvals)
+    params = _sym(matrix)
+
+    def matvec(s, p):
+        return (p + p.T) @ s
+
+    # Set up an initial vector
+    vector = jax.random.normal(jax.random.PRNGKey(1), shape=(n,))
+
+    # Flatten the inputs
+    flat, unflatten = jax.flatten_util.ravel_pytree((vector, params))
+
+    # Construct a vector-to-vector decomposition function
+    def decompose(f, *, custom_vjp):
+        kwargs = {"reortho": reortho, "custom_vjp": custom_vjp}
+        algorithm = decomp.tridiag_sym(matvec, krylov_order, **kwargs)
+        output = algorithm(*unflatten(f))
+        return jax.flatten_util.ravel_pytree(output)[0]
+
+    # Construct the two implementations
+    reference = jax.jit(functools.partial(decompose, custom_vjp=False))
+    implementation = jax.jit(functools.partial(decompose, custom_vjp=True))
+
+    # Compute both VJPs
+    fx_ref, vjp_ref = jax.vjp(reference, flat)
+    fx_imp, vjp_imp = jax.vjp(implementation, flat)
+    # Assert that the forward-passes are identical
+    assert jnp.allclose(fx_ref, fx_imp)
+
+    # Assert that the VJPs into a bunch of random directions are identical
+    for seed in [4, 5, 6]:
+        key = jax.random.PRNGKey(seed)
+        dnu = jax.random.normal(key, shape=jnp.shape(reference(flat)))
+        assert jnp.allclose(*vjp_ref(dnu), *vjp_imp(dnu), atol=1e-4, rtol=1e-4)
+
+
+def _sym(m):
+    return jnp.triu(m) - jnp.diag(0.5 * jnp.diag(m))


### PR DESCRIPTION
This PR implements gradients of the Lanczos and Arnoldi iterations according to the paper [under this link](https://arxiv.org/abs/2405.17277).

The essence of this change is that we can now take efficient reverse-mode derivatives ("gradients") through Lanczos and Arnoldi, which is useful for all sorts of machine-learning models.

As a side result, this PR fixes #181.