### PR TITLE
Improve the consistency of bidiag() and tridiag_sym()

### DIFF
--- a/matfree/decomp.py
+++ b/matfree/decomp.py
@@ -9,7 +9,7 @@ matrix-function-vector products, see
 """
 
 from matfree.backend import containers, control_flow, func, linalg, np, tree_util
-from matfree.backend.typing import Array, Callable, Tuple
+from matfree.backend.typing import Array, Callable
 
 
 def tridiag_sym(
@@ -486,22 +486,6 @@ def _extract_diag(x, offset=0):
     return linalg.diagonal_matrix(diag, offset=offset)
 
 
-class _LanczosAlg(containers.NamedTuple):
-    """Lanczos decomposition algorithm."""
-
-    init: Callable
-    """Initialise the state of the algorithm. Usually, this involves pre-allocation."""
-
-    step: Callable
-    """Compute the next iteration."""
-
-    extract: Callable
-    """Extract the solution from the state of the algorithm."""
-
-    lower_upper: Tuple[int, int]
-    """Range of the for-loop used to decompose a matrix."""
-
-
 def bidiag(
     Av: Callable, vA: Callable, depth, /, matrix_shape, validate_unit_2_norm=False
 ):
@@ -530,6 +514,17 @@ def bidiag(
         msg3 = f"for a matrix with shape {matrix_shape}."
         raise ValueError(msg1 + msg2 + msg3)
 
+    def estimate(v0, *parameters):
+        init_val = init(v0)
+
+        def body_fun(_, s):
+            return step(s, *parameters)
+
+        result = control_flow.fori_loop(
+            0, depth + 1, body_fun=body_fun, init_val=init_val
+        )
+        return extract(result)
+
     class State(containers.NamedTuple):
         i: int
         Us: Array
@@ -550,7 +545,7 @@ def bidiag(
         v0, _ = _normalise(init_vec)
         return State(0, Us, Vs, alphas, betas, np.zeros(()), v0)
 
-    def apply(state: State, *parameters) -> State:
+    def step(state: State, *parameters) -> State:
         i, Us, Vs, alphas, betas, beta, vk = state
         Vs = Vs.at[i].set(vk)
         betas = betas.at[i].set(beta)
@@ -571,62 +566,31 @@ def bidiag(
         _, uk_all, vk_all, alphas, betas, beta, vk = state
         return uk_all.T, (alphas, betas[1:]), vk_all, (beta, vk)
 
-    alg = _LanczosAlg(
-        init=init, step=apply, extract=extract, lower_upper=(0, depth + 1)
-    )
-    return func.partial(_decompose_fori_loop, algorithm=alg)
+    def _validate_unit_2_norm(v, /):
+        # todo: replace this functionality with normalising internally.
+        #
+        # Lanczos assumes a unit-2-norm vector as an input
+        # We cannot raise an error based on values of the init_vec,
+        # but we can make it obvious that the result is unusable.
+        is_not_normalized = np.abs(linalg.vector_norm(v) - 1.0) > 10 * np.finfo_eps(
+            v.dtype
+        )
+        return control_flow.cond(
+            is_not_normalized, lambda s: np.nan() * np.ones_like(s), lambda s: s, v
+        )
 
+    def _gram_schmidt_classical(vec, vectors):  # Gram-Schmidt
+        vec, coeffs = control_flow.scan(_gram_schmidt_classical_step, vec, xs=vectors)
+        vec, length = _normalise(vec)
+        return vec, length, coeffs
 
-def _validate_unit_2_norm(v, /):
-    # todo: replace this functionality with normalising internally.
-    #
-    # Lanczos assumes a unit-2-norm vector as an input
-    # We cannot raise an error based on values of the init_vec,
-    # but we can make it obvious that the result is unusable.
-    is_not_normalized = np.abs(linalg.vector_norm(v) - 1.0) > 10 * np.finfo_eps(v.dtype)
-    return control_flow.cond(
-        is_not_normalized, lambda s: np.nan() * np.ones_like(s), lambda s: s, v
-    )
+    def _gram_schmidt_classical_step(vec1, vec2):
+        coeff = linalg.inner(vec1, vec2)
+        vec_ortho = vec1 - coeff * vec2
+        return vec_ortho, coeff
 
+    def _normalise(vec):
+        length = linalg.vector_norm(vec)
+        return vec / length, length
 
-def _gram_schmidt_classical(vec, vectors):  # Gram-Schmidt
-    vec, coeffs = control_flow.scan(_gram_schmidt_classical_step, vec, xs=vectors)
-    vec, length = _normalise(vec)
-    return vec, length, coeffs
-
-
-def _gram_schmidt_classical_step(vec1, vec2):
-    coeff = linalg.inner(vec1, vec2)
-    vec_ortho = vec1 - coeff * vec2
-    return vec_ortho, coeff
-
-
-def _normalise(vec):
-    length = linalg.vector_norm(vec)
-    return vec / length, length
-
-
-def _decompose_fori_loop(v0, *parameters, algorithm: _LanczosAlg):
-    r"""Decompose a matrix purely based on matvec-products with A.
-
-    The behaviour of this function is equivalent to
-
-    ```python
-    def decompose(v0, *matvec_funs, algorithm):
-        init, step, extract, (lower, upper) = algorithm
-        state = init(v0)
-        for _ in range(lower, upper):
-            state = step(state, *matvec_funs)
-        return extract(state)
-    ```
-
-    but the implementation uses JAX' fori_loop.
-    """
-    init, step, extract, (lower, upper) = algorithm
-    init_val = init(v0)
-
-    def body_fun(_, s):
-        return step(s, *parameters)
-
-    result = control_flow.fori_loop(lower, upper, body_fun=body_fun, init_val=init_val)
-    return extract(result)
+    return estimate

--- a/matfree/decomp.py
+++ b/matfree/decomp.py
@@ -12,22 +12,6 @@ from matfree.backend import containers, control_flow, func, linalg, np, tree_uti
 from matfree.backend.typing import Array, Callable, Tuple
 
 
-class _LanczosAlg(containers.NamedTuple):
-    """Lanczos decomposition algorithm."""
-
-    init: Callable
-    """Initialise the state of the algorithm. Usually, this involves pre-allocation."""
-
-    step: Callable
-    """Compute the next iteration."""
-
-    extract: Callable
-    """Extract the solution from the state of the algorithm."""
-
-    lower_upper: Tuple[int, int]
-    """Range of the for-loop used to decompose a matrix."""
-
-
 def tridiag_sym(
     matvec, krylov_depth, /, *, reortho: str = "full", custom_vjp: bool = True
 ):
@@ -500,6 +484,22 @@ def _hessenberg_adjoint_step(
 def _extract_diag(x, offset=0):
     diag = linalg.diagonal(x, offset=offset)
     return linalg.diagonal_matrix(diag, offset=offset)
+
+
+class _LanczosAlg(containers.NamedTuple):
+    """Lanczos decomposition algorithm."""
+
+    init: Callable
+    """Initialise the state of the algorithm. Usually, this involves pre-allocation."""
+
+    step: Callable
+    """Compute the next iteration."""
+
+    extract: Callable
+    """Extract the solution from the state of the algorithm."""
+
+    lower_upper: Tuple[int, int]
+    """Range of the for-loop used to decompose a matrix."""
 
 
 def bidiag(

--- a/matfree/eig.py
+++ b/matfree/eig.py
@@ -30,7 +30,7 @@ def svd_partial(
     """
     # Factorise the matrix
     algorithm = decomp.bidiag(Av, vA, depth, matrix_shape=matrix_shape)
-    u, (d, e), vt, _ = algorithm(v0)
+    u, (d, e), vt, *_ = algorithm(v0)
 
     # Compute SVD of factorisation
     B = _bidiagonal_dense(d, e)

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -235,7 +235,7 @@ def integrand_funm_product(matfun, depth, matvec, vecmat, /):
             lambda v: matvec_flat(v)[0], vecmat_flat, depth, matrix_shape=matrix_shape
         )
         output = algorithm(v0_flat, *parameters)
-        u, (d, e), vt, _ = output
+        u, (d, e), vt, *_ = output
 
         # Compute SVD of factorisation
         B = _todense_bidiag(d, e)


### PR DESCRIPTION
* Hide all bidiag()-internal functions in the bidiag() namespace
* Make bidiag() normalise the initial vector internally (instead of verifying that it has been normalised). This changes the output signature of bidiag!