### PR TITLE
Move matvec to estimation instead of algorithm-construction to avoid future code duplication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@ test:
 	pytest
 	python -m doctest README.md
 	python -m doctest matfree/*.py
-
+	python tutorials/1_log_determinants.py
+	python tutorials/2_pytree_logdeterminants.py
+	python tutorials/3_uncertainty_quantification.py
+	python tutorials/4_control_variates.py
+	python tutorials/5_vector_calculus.py
+	python tutorials/6_low_memory_trace_estimation.py
 
 clean-preview:
 	git clean -xdn

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ Estimate the trace of the matrix:
 >>>
 >>> # Set Hutchinson's method up to compute the traces
 >>> # (instead of, e.g., diagonals)
->>> integrand = stochtrace.integrand_trace(matvec)
+>>> integrand = stochtrace.integrand_trace()
 >>>
 >>> # Compute an estimator
 >>> estimate = stochtrace.estimator(integrand, sampler)
 
 >>> # Estimate
 >>> key = jax.random.PRNGKey(1)
->>> trace = jax.jit(estimate)(key)
+>>> trace = estimate(matvec, key)
 >>>
 >>> print(trace)
 508.9

--- a/matfree/eig.py
+++ b/matfree/eig.py
@@ -29,8 +29,8 @@ def svd_partial(
         Shape of the matrix involved in matrix-vector and vector-matrix products.
     """
     # Factorise the matrix
-    algorithm = decomp.bidiag(Av, vA, depth, matrix_shape=matrix_shape)
-    u, (d, e), vt, *_ = algorithm(v0)
+    algorithm = decomp.bidiag(depth, matrix_shape=matrix_shape)
+    u, (d, e), vt, *_ = algorithm(Av, vA, v0)
 
     # Compute SVD of factorisation
     B = _bidiagonal_dense(d, e)

--- a/matfree/eig.py
+++ b/matfree/eig.py
@@ -5,6 +5,7 @@ from matfree.backend import linalg
 from matfree.backend.typing import Array, Callable, Tuple
 
 
+# todo: why does this function not return a callable?
 def svd_partial(
     v0: Array, depth: int, Av: Callable, vA: Callable, matrix_shape: Tuple[int, ...]
 ):

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -231,10 +231,9 @@ def integrand_funm_product(matfun, depth, matvec, vecmat, /):
             return tree_util.ravel_pytree(wA)[0]
 
         # Decompose into orthogonal-bidiag-orthogonal
-        algorithm = decomp.bidiag(
-            lambda v: matvec_flat(v)[0], vecmat_flat, depth, matrix_shape=matrix_shape
-        )
-        output = algorithm(v0_flat, *parameters)
+        algorithm = decomp.bidiag(depth, matrix_shape=matrix_shape)
+        matvec_flat_p = lambda v: matvec_flat(v)[0]  # noqa: E731
+        output = algorithm(matvec_flat_p, vecmat_flat, v0_flat, *parameters)
         u, (d, e), vt, *_ = output
 
         # Compute SVD of factorisation

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -31,9 +31,9 @@ Examples
 >>>
 >>> # Compute a matrix-logarithm with Lanczos' algorithm
 >>> matfun = dense_funm_sym_eigh(jnp.log)
->>> tridiag = decomp.tridiag_sym(lambda s: A @ s, 4)
+>>> tridiag = decomp.tridiag_sym(4)
 >>> matfun_vec = funm_lanczos_sym(matfun, tridiag)
->>> matfun_vec(v)
+>>> matfun_vec(lambda s: A @ s, v)
 Array([-4.1, -1.3, -2.2, -2.1, -1.2, -3.3, -0.2,  0.3,  0.7,  0.9],      dtype=float32)
 """
 
@@ -133,10 +133,10 @@ def funm_lanczos_sym(dense_funm: Callable, tridiag_sym: Callable, /) -> Callable
         [decomp.tridiag_sym][matfree.decomp.tridiag_sym].
     """
 
-    def estimate(vec, *parameters):
+    def estimate(matvec, vec, *parameters):
         length = linalg.vector_norm(vec)
         vec /= length
-        (basis, (diag, off_diag)), _ = tridiag_sym(vec, *parameters)
+        (basis, (diag, off_diag)), _ = tridiag_sym(matvec, vec, *parameters)
         matrix = _todense_tridiag_sym(diag, off_diag)
 
         funm = dense_funm(matrix)
@@ -174,8 +174,8 @@ def integrand_funm_sym(matfun, order, matvec, /):
             flat, unflatten = tree_util.ravel_pytree(Av)
             return flat
 
-        algorithm = decomp.tridiag_sym(matvec_flat, order)
-        (_, (diag, off_diag)), _ = algorithm(v0_flat, *parameters)
+        algorithm = decomp.tridiag_sym(order)
+        (_, (diag, off_diag)), _ = algorithm(matvec_flat, v0_flat, *parameters)
 
         dense = _todense_tridiag_sym(diag, off_diag)
         fA = dense_funm(dense)

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -3,14 +3,14 @@
 This includes matrix-function-vector products
 
 $$
-(f, v, p) \\mapsto f(A(p))v
+(f, A, v, p) \\mapsto f(A(p))v
 $$
 
 as well as matrix-function extensions for stochastic trace estimation,
 which provide
 
 $$
-(f, v, p) \\mapsto v^\\top f(A(p))v.
+(f, A, v, p) \\mapsto v^\\top f(A(p))v.
 $$
 
 Plug these integrands into

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -163,9 +163,9 @@ def integrand_funm_sym(matfun, order, matvec, /):
 
     This function assumes a symmetric matrix.
     """
-    # todo: if we ask the user to flatten their matvecs,
-    #  then we can give this code the same API as funm_lanczos_sym.
+    # Todo: expect these to be passed by the user.
     dense_funm = dense_funm_sym_eigh(matfun)
+    algorithm = decomp.tridiag_sym(order)
 
     def quadform(v0, *parameters):
         v0_flat, v_unflatten = tree_util.ravel_pytree(v0)
@@ -178,7 +178,6 @@ def integrand_funm_sym(matfun, order, matvec, /):
             flat, unflatten = tree_util.ravel_pytree(Av)
             return flat
 
-        algorithm = decomp.tridiag_sym(order)
         (_, (diag, off_diag)), _ = algorithm(matvec_flat, v0_flat, *parameters)
 
         dense = _todense_tridiag_sym(diag, off_diag)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -27,15 +27,15 @@ def estimator(integrand: Callable, /, sampler: Callable) -> Callable:
 
     """
 
-    def estimate(key, *parameters):
+    def estimate(matvecs, key, *parameters):
         samples = sampler(key)
-        Qs = func.vmap(lambda vec: integrand(vec, *parameters))(samples)
+        Qs = func.vmap(lambda vec: integrand(matvecs, vec, *parameters))(samples)
         return tree_util.tree_map(lambda s: np.mean(s, axis=0), Qs)
 
     return estimate
 
 
-def integrand_diagonal(matvec, /):
+def integrand_diagonal():
     """Construct the integrand for estimating the diagonal.
 
     When plugged into the Monte-Carlo estimator,
@@ -47,7 +47,7 @@ def integrand_diagonal(matvec, /):
     where ``*args_like`` is an argument of the sampler.
     """
 
-    def integrand(v, *parameters):
+    def integrand(matvec, v, *parameters):
         Qv = matvec(v, *parameters)
         v_flat, unflatten = tree_util.ravel_pytree(v)
         Qv_flat, _unflatten = tree_util.ravel_pytree(Qv)
@@ -56,10 +56,10 @@ def integrand_diagonal(matvec, /):
     return integrand
 
 
-def integrand_trace(matvec, /):
+def integrand_trace():
     """Construct the integrand for estimating the trace."""
 
-    def integrand(v, *parameters):
+    def integrand(matvec, v, *parameters):
         Qv = matvec(v, *parameters)
         v_flat, unflatten = tree_util.ravel_pytree(v)
         Qv_flat, _unflatten = tree_util.ravel_pytree(Qv)
@@ -68,10 +68,10 @@ def integrand_trace(matvec, /):
     return integrand
 
 
-def integrand_trace_and_diagonal(matvec, /):
+def integrand_trace_and_diagonal():
     """Construct the integrand for estimating the trace and diagonal jointly."""
 
-    def integrand(v, *parameters):
+    def integrand(matvec, v, *parameters):
         Qv = matvec(v, *parameters)
         v_flat, unflatten = tree_util.ravel_pytree(v)
         Qv_flat, _unflatten = tree_util.ravel_pytree(Qv)
@@ -82,10 +82,10 @@ def integrand_trace_and_diagonal(matvec, /):
     return integrand
 
 
-def integrand_frobeniusnorm_squared(matvec, /):
+def integrand_frobeniusnorm_squared():
     """Construct the integrand for estimating the squared Frobenius norm."""
 
-    def integrand(vec, *parameters):
+    def integrand(matvec, vec, *parameters):
         x = matvec(vec, *parameters)
         v_flat, unflatten = tree_util.ravel_pytree(x)
         return linalg.inner(v_flat, v_flat)

--- a/scripts/tutorials_to_py_light.py
+++ b/scripts/tutorials_to_py_light.py
@@ -19,7 +19,7 @@ def py_to_py_light(*, source, target):
 
         # Transform each python file in directory
         for i, filename_with_py in enumerate(sorted(files_src)):
-            if filename_with_py[0] != "_":
+            if filename_with_py[0] != "_" and filename_with_py[-3:] == ".py":
                 # Split docstring (to be manipulated) from rest of source
                 header, rest = split_docstring_from_content(
                     f"{dir_src}/{filename_with_py}"

--- a/tests/test_decomp/test_bidiag.py
+++ b/tests/test_decomp/test_bidiag.py
@@ -18,7 +18,7 @@ def A(nrows, ncols, num_significant_singular_vals):
 @testing.parametrize("ncols", [49])
 @testing.parametrize("num_significant_singular_vals", [4])
 @testing.parametrize("order", [6])  # ~1.5 * num_significant_eigvals
-def test_bidiag(A, order):
+def test_bidiag_decomposition_is_satisfied(A, order):
     """Test that Lanczos tridiagonalisation yields an orthogonal-tridiagonal decomp."""
     nrows, ncols = np.shape(A)
     key = prng.prng_key(1)
@@ -30,9 +30,8 @@ def test_bidiag(A, order):
     def vA(v):
         return v @ A
 
-    algorithm = decomp.bidiag(Av, vA, order, matrix_shape=np.shape(A))
-    v0 /= linalg.vector_norm(v0)
-    Us, Bs, Vs, (b, v), ln = algorithm(v0)
+    algorithm = decomp.bidiag(order, matrix_shape=np.shape(A))
+    Us, Bs, Vs, (b, v), ln = algorithm(Av, vA, v0)
     (d_m, e_m) = Bs
 
     tols_decomp = {"atol": 1e-5, "rtol": 1e-5}
@@ -71,11 +70,7 @@ def test_error_too_high_depth(A):
     max_depth = min(nrows, ncols) - 1
 
     with testing.raises(ValueError, match=""):
-
-        def eye(v):
-            return v
-
-        _ = decomp.bidiag(eye, eye, max_depth + 1, matrix_shape=np.shape(A))
+        _ = decomp.bidiag(max_depth + 1, matrix_shape=np.shape(A))
 
 
 @testing.parametrize("nrows", [5])
@@ -85,11 +80,7 @@ def test_error_too_low_depth(A):
     """Assert that a ValueError is raised when the depth is negative."""
     min_depth = 0
     with testing.raises(ValueError, match=""):
-
-        def eye(v):
-            return v
-
-        _ = decomp.bidiag(eye, eye, min_depth - 1, matrix_shape=np.shape(A))
+        _ = decomp.bidiag(min_depth - 1, matrix_shape=np.shape(A))
 
 
 @testing.parametrize("nrows", [15])
@@ -107,8 +98,8 @@ def test_no_error_zero_depth(A):
     def vA(v):
         return v @ A
 
-    algorithm = decomp.bidiag(Av, vA, 0, matrix_shape=np.shape(A))
-    Us, Bs, Vs, (b, v), ln = algorithm(v0)
+    algorithm = decomp.bidiag(0, matrix_shape=np.shape(A))
+    Us, Bs, Vs, (b, v), ln = algorithm(Av, vA, v0)
     (d_m, e_m) = Bs
     assert np.shape(Us) == (nrows, 1)
     assert np.shape(Vs) == (1, ncols)

--- a/tests/test_decomp/test_hessenberg.py
+++ b/tests/test_decomp/test_hessenberg.py
@@ -14,8 +14,8 @@ def test_decomposition_is_satisfied(nrows, krylov_depth, reortho, dtype):
     v = prng.normal(prng.prng_key(2), shape=(nrows,), dtype=dtype)
 
     # Decompose
-    algorithm = decomp.hessenberg(lambda s, p: p @ s, krylov_depth, reortho=reortho)
-    Q, H, r, c = algorithm(v, A)
+    algorithm = decomp.hessenberg(krylov_depth, reortho=reortho)
+    Q, H, r, c = algorithm(lambda s, p: p @ s, v, A)
 
     # Assert shapes
     assert Q.shape == (nrows, krylov_depth)
@@ -43,8 +43,8 @@ def test_reorthogonalisation_improves_the_estimate(nrows, krylov_depth, reortho)
     v = prng.normal(prng.prng_key(2), shape=(nrows,))
 
     # Decompose
-    algorithm = decomp.hessenberg(lambda s, p: p @ s, krylov_depth, reortho=reortho)
-    Q, H, r, c = algorithm(v, A)
+    algorithm = decomp.hessenberg(krylov_depth, reortho=reortho)
+    Q, H, r, c = algorithm(lambda s, p: p @ s, v, A)
 
     # Assert shapes
     assert Q.shape == (nrows, krylov_depth)
@@ -64,18 +64,18 @@ def test_reorthogonalisation_improves_the_estimate(nrows, krylov_depth, reortho)
 
 
 def test_raises_error_for_wrong_depth_too_small():
-    algorithm = decomp.hessenberg(lambda s: s, 0, reortho="none")
+    algorithm = decomp.hessenberg(0, reortho="none")
     with testing.raises(ValueError, match="depth"):
-        _ = algorithm(np.ones((2,)))
+        _ = algorithm(lambda s: s, np.ones((2,)))
 
 
 def test_raises_error_for_wrong_depth_too_high():
-    algorithm = decomp.hessenberg(lambda s: s, 3, reortho="none")
+    algorithm = decomp.hessenberg(3, reortho="none")
     with testing.raises(ValueError, match="depth"):
-        _ = algorithm(np.ones((2,)))
+        _ = algorithm(lambda s: s, np.ones((2,)))
 
 
 @testing.parametrize("reortho_wrong", [True, "full_with_sparsity", "None"])
 def test_raises_error_for_wrong_reorthogonalisation_flag(reortho_wrong):
     with testing.raises(TypeError, match="Unexpected input"):
-        _ = decomp.hessenberg(lambda s: s, 1, reortho=reortho_wrong)
+        _ = decomp.hessenberg(1, reortho=reortho_wrong)

--- a/tests/test_decomp/test_tridiag_sym.py
+++ b/tests/test_decomp/test_tridiag_sym.py
@@ -13,8 +13,8 @@ def test_full_rank_reconstruction_is_exact(reortho, ndim):
     vector = np.flip(np.arange(1.0, 1.0 + len(eigvals)))
 
     # Run Lanczos approximation
-    algorithm = decomp.tridiag_sym(lambda s, p: p @ s, ndim, reortho=reortho)
-    (lanczos_vectors, tridiag), _ = algorithm(vector, matrix)
+    algorithm = decomp.tridiag_sym(ndim, reortho=reortho)
+    (lanczos_vectors, tridiag), _ = algorithm(lambda s, p: p @ s, vector, matrix)
 
     # Reconstruct the original matrix from the full-order approximation
     dense_matrix = _dense_tridiag_sym(*tridiag)
@@ -46,8 +46,8 @@ def test_mid_rank_reconstruction_satisfies_decomposition(ndim, krylov_depth, reo
     vector = np.flip(np.arange(1.0, 1.0 + len(eigvals)))
 
     # Run Lanczos approximation
-    algorithm = decomp.tridiag_sym(lambda s, p: p @ s, krylov_depth, reortho=reortho)
-    (lanczos_vectors, tridiag), (q, b) = algorithm(vector, matrix)
+    algorithm = decomp.tridiag_sym(krylov_depth, reortho=reortho)
+    (lanczos_vectors, tridiag), (q, b) = algorithm(lambda s, p: p @ s, vector, matrix)
 
     # Verify the decomposition
     Q, T = lanczos_vectors, _dense_tridiag_sym(*tridiag)

--- a/tests/test_decomp/test_tridiag_sym_adjoint.py
+++ b/tests/test_decomp/test_tridiag_sym_adjoint.py
@@ -24,8 +24,8 @@ def test_adjoint_vjp_matches_jax_vjp(reortho, n=10, krylov_order=4):
     # Construct a vector-to-vector decomposition function
     def decompose(f, *, custom_vjp):
         kwargs = {"reortho": reortho, "custom_vjp": custom_vjp}
-        algorithm = decomp.tridiag_sym(matvec, krylov_order, **kwargs)
-        output = algorithm(*unflatten(f))
+        algorithm = decomp.tridiag_sym(krylov_order, **kwargs)
+        output = algorithm(matvec, *unflatten(f))
         return tree_util.ravel_pytree(output)[0]
 
     # Construct the two implementations

--- a/tests/test_funm/test_funm_lanczos_sym.py
+++ b/tests/test_funm/test_funm_lanczos_sym.py
@@ -28,7 +28,7 @@ def test_funm_lanczos_sym_matches_eigh_implementation(dense_funm, n=11):
 
     # Compute the matrix-function vector product
     dense_funm = dense_funm(fun)
-    lanczos = decomp.tridiag_sym(matvec, 6)
+    lanczos = decomp.tridiag_sym(6)
     matfun_vec = funm.funm_lanczos_sym(dense_funm, lanczos)
-    received = matfun_vec(v, matrix)
+    received = matfun_vec(matvec, v, matrix)
     assert np.allclose(expected, received, atol=1e-6)

--- a/tests/test_funm/test_funm_lanczos_sym.py
+++ b/tests/test_funm/test_funm_lanczos_sym.py
@@ -29,6 +29,6 @@ def test_funm_lanczos_sym_matches_eigh_implementation(dense_funm, n=11):
     # Compute the matrix-function vector product
     dense_funm = dense_funm(fun)
     lanczos = decomp.tridiag_sym(6)
-    matfun_vec = funm.funm_lanczos_sym(dense_funm, lanczos)
-    received = matfun_vec(matvec, v, matrix)
+    matfun_vec = funm.funm_lanczos_sym(matvec, dense_funm, lanczos)
+    received = matfun_vec(v, matrix)
     assert np.allclose(expected, received, atol=1e-6)

--- a/tests/test_funm/test_funm_lanczos_sym.py
+++ b/tests/test_funm/test_funm_lanczos_sym.py
@@ -29,6 +29,6 @@ def test_funm_lanczos_sym_matches_eigh_implementation(dense_funm, n=11):
     # Compute the matrix-function vector product
     dense_funm = dense_funm(fun)
     lanczos = decomp.tridiag_sym(6)
-    matfun_vec = funm.funm_lanczos_sym(matvec, dense_funm, lanczos)
-    received = matfun_vec(v, matrix)
+    matfun_vec = funm.funm_lanczos_sym(dense_funm, lanczos)
+    received = matfun_vec(matvec, v, matrix)
     assert np.allclose(expected, received, atol=1e-6)

--- a/tests/test_funm/test_integrand_funm_logdet_product.py
+++ b/tests/test_funm/test_integrand_funm_logdet_product.py
@@ -31,9 +31,9 @@ def test_logdet_product(A, order):
 
     x_like = {"fx": np.ones((ncols,), dtype=float)}
     fun = stochtrace.sampler_normal(x_like, num=400)
-    problem = funm.integrand_funm_product_logdet(order, matvec, vecmat)
+    problem = funm.integrand_funm_product_logdet(order)
     estimate = stochtrace.estimator(problem, fun)
-    received = estimate(key)
+    received = estimate((matvec, vecmat), key)
 
     expected = linalg.slogdet(A.T @ A)[1]
     print_if_assert_fails = ("error", np.abs(received - expected), "target:", expected)
@@ -53,15 +53,13 @@ def test_logdet_product_exact_for_full_order_lanczos(n):
 
     # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
     order = n - 1
-    integrand = funm.integrand_funm_product_logdet(
-        order, lambda v: A @ v, lambda v: v @ A
-    )
+    integrand = funm.integrand_funm_product_logdet(order)
 
     # Construct a vector without that does not have expected 2-norm equal to "dim"
     x = prng.normal(prng.prng_key(seed=1), shape=(n,)) + 1
 
     # Compute v^\top @ log(A) @ v via Lanczos
-    received = integrand(x)
+    received = integrand((lambda v: A @ v, lambda v: v @ A), x)
 
     # Compute the "true" value of v^\top @ log(A) @ v via eigenvalues
     eigvals, eigvecs = linalg.eigh(A.T @ A)

--- a/tests/test_funm/test_integrand_funm_logdet_sym.py
+++ b/tests/test_funm/test_integrand_funm_logdet_sym.py
@@ -29,9 +29,9 @@ def test_logdet_spd(A, order):
     key = prng.prng_key(1)
     args_like = {"fx": np.ones((n,), dtype=float)}
     sampler = stochtrace.sampler_normal(args_like, num=10)
-    integrand = funm.integrand_funm_sym_logdet(order, matvec)
+    integrand = funm.integrand_funm_sym_logdet(order)
     estimate = stochtrace.estimator(integrand, sampler)
-    received = estimate(key)
+    received = estimate(matvec, key)
 
     expected = linalg.slogdet(A)[1]
     print_if_assert_fails = ("error", np.abs(received - expected), "target:", expected)
@@ -49,13 +49,13 @@ def test_logdet_spd_exact_for_full_order_lanczos(n):
 
     # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
     order = n - 1
-    integrand = funm.integrand_funm_sym_logdet(order, lambda v: A @ v)
+    integrand = funm.integrand_funm_sym_logdet(order)
 
     # Construct a vector without that does not have expected 2-norm equal to "dim"
     x = prng.normal(prng.prng_key(seed=1), shape=(n,)) + 10
 
     # Compute v^\top @ log(A) @ v via Lanczos
-    received = integrand(x)
+    received = integrand(lambda v: A @ v, x)
 
     # Compute the "true" value of v^\top @ log(A) @ v via eigenvalues
     eigvals, eigvecs = linalg.eigh(A)

--- a/tests/test_funm/test_integrand_funm_schatten_norm.py
+++ b/tests/test_funm/test_integrand_funm_schatten_norm.py
@@ -27,13 +27,11 @@ def test_schatten_norm(A, order, power):
     _, ncols = np.shape(A)
     args_like = np.ones((ncols,), dtype=float)
     sampler = stochtrace.sampler_normal(args_like, num=500)
-    integrand = funm.integrand_funm_product_schatten_norm(
-        power, order, lambda v: A @ v, lambda v: A.T @ v
-    )
+    integrand = funm.integrand_funm_product_schatten_norm(power, order)
     estimate = stochtrace.estimator(integrand, sampler)
 
     key = prng.prng_key(1)
-    received = estimate(key)
+    received = estimate((lambda v: A @ v, lambda v: A.T @ v), key)
 
     print_if_assert_fails = ("error", np.abs(received - expected), "target:", expected)
     assert np.allclose(received, expected, atol=1e-2, rtol=1e-2), print_if_assert_fails

--- a/tests/test_stochtrace/test_diagonal.py
+++ b/tests/test_stochtrace/test_diagonal.py
@@ -23,10 +23,10 @@ def test_diagonal():
     expected = tree_util.tree_map(linalg.diagonal, J)
 
     # Estimate the matrix function
-    problem = stochtrace.integrand_diagonal(jvp)
+    problem = stochtrace.integrand_diagonal()
     sampler = stochtrace.sampler_normal(args_like, num=100_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    received = estimate(key)
+    received = estimate(jvp, key)
 
     def compare(a, b):
         return np.allclose(a, b, rtol=1e-2)

--- a/tests/test_stochtrace/test_frobeniusnorm_squared.py
+++ b/tests/test_stochtrace/test_frobeniusnorm_squared.py
@@ -22,9 +22,9 @@ def test_frobeniusnorm_squared():
     expected = linalg.trace(J.T @ J)
 
     # Estimate the matrix function
-    problem = stochtrace.integrand_frobeniusnorm_squared(jvp)
+    problem = stochtrace.integrand_frobeniusnorm_squared()
     sampler = stochtrace.sampler_rademacher(args_like, num=100_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    received = estimate(key)
+    received = estimate(jvp, key)
 
     assert np.allclose(expected, received, rtol=1e-2)

--- a/tests/test_stochtrace/test_trace.py
+++ b/tests/test_stochtrace/test_trace.py
@@ -22,10 +22,10 @@ def test_trace():
     expected = linalg.trace(J)
 
     # Estimate the matrix function
-    problem = stochtrace.integrand_trace(jvp)
+    problem = stochtrace.integrand_trace()
     sampler = stochtrace.sampler_normal(args_like, num=100_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    received = estimate(key)
+    received = estimate(jvp, key)
 
     def compare(a, b):
         return np.allclose(a, b, rtol=1e-2)

--- a/tests/test_stochtrace/test_trace_and_diagonal.py
+++ b/tests/test_stochtrace/test_trace_and_diagonal.py
@@ -20,22 +20,22 @@ def test_trace_and_diagonal():
     _, jvp = func.linearize(fun, args_like)
 
     # Estimate the matrix function
-    problem = stochtrace.integrand_trace_and_diagonal(jvp)
+    problem = stochtrace.integrand_trace_and_diagonal()
     sampler = stochtrace.sampler_rademacher(args_like, num=100_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    received = estimate(key)
+    received = estimate(jvp, key)
 
     # Estimate the trace
-    problem = stochtrace.integrand_trace(jvp)
+    problem = stochtrace.integrand_trace()
     sampler = stochtrace.sampler_rademacher(args_like, num=100_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    expected_trace = estimate(key)
+    expected_trace = estimate(jvp, key)
 
     # Estimate the diagonal
-    problem = stochtrace.integrand_diagonal(jvp)
+    problem = stochtrace.integrand_diagonal()
     sampler = stochtrace.sampler_rademacher(args_like, num=100_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    expected_diagonal = estimate(key)
+    expected_diagonal = estimate(jvp, key)
 
     expected = {"trace": expected_trace, "diagonal": expected_diagonal}
 

--- a/tests/test_stochtrace/test_wrap_moments.py
+++ b/tests/test_stochtrace/test_wrap_moments.py
@@ -20,13 +20,13 @@ def test_yields_correct_tree_structure():
     _, jvp = func.linearize(fun, args_like)
 
     # Estimate the matrix function
-    problem = stochtrace.integrand_diagonal(jvp)
+    problem = stochtrace.integrand_diagonal()
     problem = stochtrace.integrand_wrap_moments(
         problem, moments={"moment_1st": 1, "moment_2nd": 2}
     )
     sampler = stochtrace.sampler_normal(args_like, num=100_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    received = estimate(key)
+    received = estimate(jvp, key)
 
     irrelevant_value = 1.1
     expected = {
@@ -60,11 +60,11 @@ def test_yields_correct_variance_normal(J_and_jvp, key):
     """Assert that the estimated trace approximates the true trace accurately."""
     # Estimate the trace
     J, jvp, args_like = J_and_jvp
-    problem = stochtrace.integrand_trace(jvp)
+    problem = stochtrace.integrand_trace()
     problem = stochtrace.integrand_wrap_moments(problem, moments=[1, 2])
     sampler = stochtrace.sampler_normal(args_like, num=1_000_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    first, second = estimate(key)
+    first, second = estimate(jvp, key)
 
     # Assert the trace is correct
     truth = linalg.trace(J)
@@ -80,11 +80,11 @@ def test_yields_correct_variance_rademacher(J_and_jvp, key):
     # Estimate the trace
     J, jvp, args_like = J_and_jvp
 
-    problem = stochtrace.integrand_trace(jvp)
+    problem = stochtrace.integrand_trace()
     problem = stochtrace.integrand_wrap_moments(problem, moments=[1, 2])
     sampler = stochtrace.sampler_rademacher(args_like, num=500)
     estimate = stochtrace.estimator(problem, sampler=sampler)
-    first, second = estimate(key)
+    first, second = estimate(jvp, key)
 
     # Assert the trace is correct
     truth = linalg.trace(J)

--- a/tutorials/1_log_determinants.py
+++ b/tutorials/1_log_determinants.py
@@ -27,10 +27,10 @@ x_like = jnp.ones((nrows,), dtype=float)  # use to determine shapes of vectors
 # Estimate log-determinants with stochastic Lanczos quadrature.
 
 order = 3
-problem = funm.integrand_funm_sym_logdet(order, matvec)
+problem = funm.integrand_funm_sym_logdet(order)
 sampler = stochtrace.sampler_normal(x_like, num=1_000)
 estimator = stochtrace.estimator(problem, sampler=sampler)
-logdet = estimator(jax.random.PRNGKey(1))
+logdet = estimator(matvec, jax.random.PRNGKey(1))
 print(logdet)
 
 # For comparison:
@@ -58,10 +58,10 @@ def vecmat_l(x):
 
 
 order = 3
-problem = funm.integrand_funm_product_logdet(order, matvec_r, vecmat_l)
+problem = funm.integrand_funm_product_logdet(order)
 sampler = stochtrace.sampler_normal(x_like, num=1_000)
 estimator = stochtrace.estimator(problem, sampler=sampler)
-logdet = estimator(jax.random.PRNGKey(1))
+logdet = estimator((matvec_r, vecmat_l), jax.random.PRNGKey(1))
 print(logdet)
 
 # For comparison:

--- a/tutorials/2_pytree_logdeterminants.py
+++ b/tutorials/2_pytree_logdeterminants.py
@@ -53,11 +53,11 @@ def make_matvec(alpha):
 
 matvec = make_matvec(alpha=0.1)
 order = 3
-integrand = funm.integrand_funm_sym_logdet(order, matvec)
+integrand = funm.integrand_funm_sym_logdet(order)
 sample_fun = stochtrace.sampler_normal(f0, num=10)
 estimator = stochtrace.estimator(integrand, sampler=sample_fun)
 key = jax.random.PRNGKey(1)
-logdet = estimator(key)
+logdet = estimator(matvec, key)
 print(logdet)
 
 

--- a/tutorials/3_uncertainty_quantification.py
+++ b/tutorials/3_uncertainty_quantification.py
@@ -26,10 +26,10 @@ num_samples = 10_000
 # Sometimes, second and higher moments of a random variable are interesting.
 
 normal = stochtrace.sampler_normal(x_like, num=num_samples)
-integrand = stochtrace.integrand_trace(matvec)
+integrand = stochtrace.integrand_trace()
 integrand = stochtrace.integrand_wrap_moments(integrand, [1, 2])
 estimator = stochtrace.estimator(integrand, sampler=normal)
-first, second = estimator(jax.random.PRNGKey(1))
+first, second = estimator(matvec, jax.random.PRNGKey(1))
 
 
 # For normally-distributed base-samples,

--- a/tutorials/4_control_variates.py
+++ b/tutorials/4_control_variates.py
@@ -24,26 +24,30 @@ sample_fun = stochtrace.sampler_normal(x_like, num=10_000)
 # First, compute the diagonal.
 
 
-problem = stochtrace.integrand_diagonal(lambda v: A @ v)
+problem = stochtrace.integrand_diagonal()
 estimate = stochtrace.estimator(problem, sample_fun)
-diagonal_ctrl = estimate(jax.random.PRNGKey(1))
+diagonal_ctrl = estimate(lambda v: A @ v, jax.random.PRNGKey(1))
 
 
 # Then, compute trace and diagonal jointly
 # using the estimate of the diagonal as a control variate.
 
 
-problem = stochtrace.integrand_trace_and_diagonal(lambda v: A @ v - diagonal_ctrl * v)
+def matvec_ctrl(v):
+    return A @ v - diagonal_ctrl * v
+
+
+problem = stochtrace.integrand_trace_and_diagonal()
 estimate = stochtrace.estimator(problem, sample_fun)
-trace_and_diagonal = estimate(jax.random.PRNGKey(2))
+trace_and_diagonal = estimate(matvec_ctrl, jax.random.PRNGKey(2))
 trace, diagonal = trace_and_diagonal["trace"], trace_and_diagonal["diagonal"]
 
 
 # We can, of course, compute it without a control variate as well.
 
-problem = stochtrace.integrand_trace_and_diagonal(lambda v: A @ v)
+problem = stochtrace.integrand_trace_and_diagonal()
 estimate = stochtrace.estimator(problem, sample_fun)
-trace_and_diagonal = estimate(jax.random.PRNGKey(2))
+trace_and_diagonal = estimate(lambda v: A @ v, jax.random.PRNGKey(2))
 trace_ref, diagonal_ref = trace_and_diagonal["trace"], trace_and_diagonal["diagonal"]
 
 

--- a/tutorials/5_vector_calculus.py
+++ b/tutorials/5_vector_calculus.py
@@ -64,10 +64,10 @@ def divergence_matfree(vf, /, *, num):
 
     def divergence(k, x):
         _fx, jvp = jax.linearize(vf, x)
-        integrand_laplacian = stochtrace.integrand_trace(jvp)
+        integrand_laplacian = stochtrace.integrand_trace()
         normal = stochtrace.sampler_normal(x, num=num)
         estimator = stochtrace.estimator(integrand_laplacian, sampler=normal)
-        return estimator(k)
+        return estimator(jvp, k)
 
     return divergence
 

--- a/tutorials/6_low_memory_trace_estimation.py
+++ b/tutorials/6_low_memory_trace_estimation.py
@@ -12,6 +12,8 @@ Here is how we can wrap calls around the trace estimators
 in such a scenario to save memory.
 """
 
+import functools
+
 import jax
 import jax.numpy as jnp
 
@@ -30,14 +32,13 @@ def large_matvec(v):
     return 1.2345 * v
 
 
-integrand = stochtrace.integrand_trace(large_matvec)
-
+integrand = stochtrace.integrand_trace()
 x0 = jnp.ones((nrows,))
 sampler = stochtrace.sampler_rademacher(x0, num=nsamples)
 estimate = stochtrace.estimator(integrand, sampler)
 
 key = jax.random.PRNGKey(1)
-trace = estimate(key)
+trace = estimate(large_matvec, key)
 print(trace)
 
 
@@ -48,6 +49,7 @@ print(trace)
 
 sampler = stochtrace.sampler_rademacher(x0, num=1)
 estimate = stochtrace.estimator(integrand, sampler)
+estimate = functools.partial(estimate, large_matvec)
 
 key = jax.random.PRNGKey(2)
 keys = jax.random.split(key, num=nsamples)


### PR DESCRIPTION
**Many of Matfree's functions manipulate matrix-vector products before calling other Matfree-functions, which leads to unnecessary code duplication in Matfree's current state.** For example, `funm.integrand_funm_*` flattens matrix-vector product code before calling decompositions from decomp.py. Since `matvec`-style arguments are currently part of the algorithm-constructors instead of the `estimate`-style functions that these constructors return, it is difficult to patch together methods. As a symptom, every matrix decomposition has a twin in `funm.integrand_funm_*`, even though the overall code for these integrands does not change much.

**This PR solves this issue by making `matvec` an argument to `estimate`, not an argument to `construct_algorithm`.**
The changes affect most of Matfree and break existing code, but updating is very simple (see the diff for examples).
This implies that in the near future, we can build algorithms for functions of matrices without duplicating all matrix decompositions, which will lead to massive code reductions.
 