### PR TITLE
Add a 'materialize' option to tridiag() and bidiag() to simplify downstream applications

### DIFF
--- a/matfree/eig.py
+++ b/matfree/eig.py
@@ -30,11 +30,10 @@ def svd_partial(
         Shape of the matrix involved in matrix-vector and vector-matrix products.
     """
     # Factorise the matrix
-    algorithm = decomp.bidiag(depth, matrix_shape=matrix_shape)
-    u, (d, e), vt, *_ = algorithm(Av, vA, v0)
+    algorithm = decomp.bidiag(depth, matrix_shape=matrix_shape, materialize=True)
+    u, B, vt, *_ = algorithm(Av, vA, v0)
 
     # Compute SVD of factorisation
-    B = _bidiagonal_dense(d, e)
     U, S, Vt = linalg.svd(B, full_matrices=False)
 
     # Combine orthogonal transformations

--- a/tests/test_decomp/test_bidiag.py
+++ b/tests/test_decomp/test_bidiag.py
@@ -30,7 +30,7 @@ def test_bidiag_decomposition_is_satisfied(A, order):
     def vA(v):
         return v @ A
 
-    algorithm = decomp.bidiag(order, matrix_shape=np.shape(A))
+    algorithm = decomp.bidiag(order, matrix_shape=np.shape(A), materialize=False)
     Us, Bs, Vs, (b, v), ln = algorithm(Av, vA, v0)
     (d_m, e_m) = Bs
 
@@ -70,7 +70,7 @@ def test_error_too_high_depth(A):
     max_depth = min(nrows, ncols) - 1
 
     with testing.raises(ValueError, match=""):
-        _ = decomp.bidiag(max_depth + 1, matrix_shape=np.shape(A))
+        _ = decomp.bidiag(max_depth + 1, matrix_shape=np.shape(A), materialize=False)
 
 
 @testing.parametrize("nrows", [5])
@@ -80,7 +80,7 @@ def test_error_too_low_depth(A):
     """Assert that a ValueError is raised when the depth is negative."""
     min_depth = 0
     with testing.raises(ValueError, match=""):
-        _ = decomp.bidiag(min_depth - 1, matrix_shape=np.shape(A))
+        _ = decomp.bidiag(min_depth - 1, matrix_shape=np.shape(A), materialize=False)
 
 
 @testing.parametrize("nrows", [15])
@@ -98,7 +98,7 @@ def test_no_error_zero_depth(A):
     def vA(v):
         return v @ A
 
-    algorithm = decomp.bidiag(0, matrix_shape=np.shape(A))
+    algorithm = decomp.bidiag(0, matrix_shape=np.shape(A), materialize=False)
     Us, Bs, Vs, (b, v), ln = algorithm(Av, vA, v0)
     (d_m, e_m) = Bs
     assert np.shape(Us) == (nrows, 1)

--- a/tests/test_decomp/test_tridiag_sym_adjoint.py
+++ b/tests/test_decomp/test_tridiag_sym_adjoint.py
@@ -23,7 +23,7 @@ def test_adjoint_vjp_matches_jax_vjp(reortho, n=10, krylov_order=4):
 
     # Construct a vector-to-vector decomposition function
     def decompose(f, *, custom_vjp):
-        kwargs = {"reortho": reortho, "custom_vjp": custom_vjp}
+        kwargs = {"reortho": reortho, "custom_vjp": custom_vjp, "materialize": False}
         algorithm = decomp.tridiag_sym(krylov_order, **kwargs)
         output = algorithm(matvec, *unflatten(f))
         return tree_util.ravel_pytree(output)[0]

--- a/tests/test_funm/test_funm_lanczos_sym.py
+++ b/tests/test_funm/test_funm_lanczos_sym.py
@@ -5,7 +5,8 @@ from matfree.backend import linalg, np, prng, testing
 
 
 @testing.parametrize("dense_funm", [funm.dense_funm_sym_eigh, funm.dense_funm_schur])
-def test_funm_lanczos_sym_matches_eigh_implementation(dense_funm, n=11):
+@testing.parametrize("reortho", ["full", "none"])
+def test_funm_lanczos_sym_matches_eigh_implementation(dense_funm, reortho, n=11):
     """Test matrix-function-vector products via Lanczos' algorithm."""
     # Create a test-problem: matvec, matrix function,
     # vector, and parameters (a matrix).
@@ -28,7 +29,7 @@ def test_funm_lanczos_sym_matches_eigh_implementation(dense_funm, n=11):
 
     # Compute the matrix-function vector product
     dense_funm = dense_funm(fun)
-    lanczos = decomp.tridiag_sym(6)
+    lanczos = decomp.tridiag_sym(6, materialize=True, reortho=reortho)
     matfun_vec = funm.funm_lanczos_sym(dense_funm, lanczos)
     received = matfun_vec(matvec, v, matrix)
     assert np.allclose(expected, received, atol=1e-6)


### PR DESCRIPTION
Most applications of tridiagonalisation and bidiatonalisation require materialising the tri/bidiagonal matrices and doing linear algebra with those dense matrices.
Currently, all applications of bi/tridiagonalisation (including funm, eig, and tests) have a function like "todense_tri/bidiagonal", and there is not a single use of the coefficients without materialising the matrices in the entire library.


**This PR introduces an option for materialising those matrices as part of the decompositions.**
This `materialize` flag is set to `True` by default, but can be set to `False` to recover the previous implementation.
Functions of matrices require that `materialize` is set to True.

As a result, future version of Matfree can write integrand_funm agnostic of the decomposition, which will simplify a lot of code.