### PR TITLE
Make integrand_funm_product_* expect algorithms as inputs (not algorithm parameters)

### DIFF
--- a/matfree/eig.py
+++ b/matfree/eig.py
@@ -2,13 +2,11 @@
 
 from matfree import decomp
 from matfree.backend import linalg
-from matfree.backend.typing import Array, Callable, Tuple
+from matfree.backend.typing import Array, Callable
 
 
 # todo: why does this function not return a callable?
-def svd_partial(
-    v0: Array, depth: int, Av: Callable, vA: Callable, matrix_shape: Tuple[int, ...]
-):
+def svd_partial(v0: Array, depth: int, Av: Callable, vA: Callable):
     """Partial singular value decomposition.
 
     Combines bidiagonalisation with full reorthogonalisation
@@ -30,7 +28,7 @@ def svd_partial(
         Shape of the matrix involved in matrix-vector and vector-matrix products.
     """
     # Factorise the matrix
-    algorithm = decomp.bidiag(depth, matrix_shape=matrix_shape, materialize=True)
+    algorithm = decomp.bidiag(depth, materialize=True)
     (u, v), B, *_ = algorithm(Av, vA, v0)
 
     # Compute SVD of factorisation

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -37,7 +37,6 @@ Examples
 
 """
 
-from matfree import decomp
 from matfree.backend import containers, control_flow, func, linalg, np, tree_util
 from matfree.backend.typing import Array, Callable
 
@@ -232,29 +231,28 @@ def integrand_funm_sym(dense_funm, tridiag_sym, /):
     return quadform
 
 
-# todo: expect bidiag() to be passed here
-def integrand_funm_product_logdet(depth, /):
+def integrand_funm_product_logdet(bidiag: Callable, /):
     r"""Construct the integrand for the log-determinant of a matrix-product.
 
     Here, "product" refers to $X = A^\top A$.
     """
-    return integrand_funm_product(np.log, depth)
+    return integrand_funm_product(np.log, bidiag)
 
 
 # todo: expect bidiag() to be passed here
-def integrand_funm_product_schatten_norm(power, depth, /):
+def integrand_funm_product_schatten_norm(power, bidiag: Callable, /):
     r"""Construct the integrand for the $p$-th power of the Schatten-p norm."""
 
     def matfun(x):
         """Matrix-function for Schatten-p norms."""
         return x ** (power / 2)
 
-    return integrand_funm_product(matfun, depth)
+    return integrand_funm_product(matfun, bidiag)
 
 
 # todo: expect bidiag() to be passed here
 # todo: expect dense_funm_svd() to be passed here
-def integrand_funm_product(matfun, depth, /):
+def integrand_funm_product(matfun, algorithm, /):
     r"""Construct the integrand for matrix-function-trace estimation.
 
     Instead of the trace of a function of a matrix,
@@ -277,8 +275,6 @@ def integrand_funm_product(matfun, depth, /):
             return flat, tree_util.partial_pytree(unflatten)
 
         w0_flat, w_unflatten = func.eval_shape(matvec_flat, v0_flat)
-        matrix_shape = (*np.shape(w0_flat), *np.shape(v0_flat))
-        algorithm = decomp.bidiag(depth, matrix_shape=matrix_shape, materialize=True)
 
         def vecmat_flat(w_flat):
             w = w_unflatten(w_flat)

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -236,10 +236,10 @@ def integrand_funm_product_logdet(bidiag: Callable, /):
 
     Here, "product" refers to $X = A^\top A$.
     """
-    return integrand_funm_product(np.log, bidiag)
+    dense_funm = dense_funm_product_svd(np.log)
+    return integrand_funm_product(dense_funm, bidiag)
 
 
-# todo: expect bidiag() to be passed here
 def integrand_funm_product_schatten_norm(power, bidiag: Callable, /):
     r"""Construct the integrand for the $p$-th power of the Schatten-p norm."""
 
@@ -247,20 +247,17 @@ def integrand_funm_product_schatten_norm(power, bidiag: Callable, /):
         """Matrix-function for Schatten-p norms."""
         return x ** (power / 2)
 
-    return integrand_funm_product(matfun, bidiag)
+    dense_funm = dense_funm_product_svd(matfun)
+    return integrand_funm_product(dense_funm, bidiag)
 
 
-# todo: expect bidiag() to be passed here
-# todo: expect dense_funm_svd() to be passed here
-def integrand_funm_product(matfun, algorithm, /):
+def integrand_funm_product(dense_funm, algorithm, /):
     r"""Construct the integrand for matrix-function-trace estimation.
 
     Instead of the trace of a function of a matrix,
     compute the trace of a function of the product of matrices.
     Here, "product" refers to $X = A^\top A$.
     """
-
-    dense_funm = dense_funm_product_svd(matfun)
 
     def quadform(matvecs, v0, *parameters):
         matvec, vecmat = matvecs
@@ -294,6 +291,8 @@ def integrand_funm_product(matfun, algorithm, /):
 
 
 def dense_funm_product_svd(matfun):
+    """Implement dense matrix-functions of a product of matrices via SVDs."""
+
     def dense_funm(matrix, /):
         # Compute SVD of factorisation
         _, S, Vt = linalg.svd(matrix, full_matrices=False)
@@ -307,7 +306,6 @@ def dense_funm_product_svd(matfun):
     return dense_funm
 
 
-# todo: rename to *_eigh_sym
 def dense_funm_sym_eigh(matfun):
     """Implement dense matrix-functions via symmetric eigendecompositions.
 

--- a/tests/test_decomp/test_bidiag.py
+++ b/tests/test_decomp/test_bidiag.py
@@ -31,7 +31,7 @@ def test_bidiag_decomposition_is_satisfied(
     def vA(v):
         return v @ A
 
-    algorithm = decomp.bidiag(order, matrix_shape=np.shape(A), materialize=True)
+    algorithm = decomp.bidiag(order, materialize=True)
     (U, V), B, res, ln = algorithm(Av, vA, v0)
 
     test_util.assert_columns_orthonormal(U)
@@ -52,7 +52,8 @@ def test_error_too_high_depth(nrows, ncols, num_significant_singular_vals):
     max_depth = min(nrows, ncols) - 1
 
     with testing.raises(ValueError, match=""):
-        _ = decomp.bidiag(max_depth + 1, matrix_shape=np.shape(A), materialize=False)
+        alg = decomp.bidiag(max_depth + 1, materialize=False)
+        _ = alg(lambda v: A @ v, lambda v: A.T @ v, A[0])
 
 
 @testing.parametrize("nrows", [5])
@@ -63,7 +64,8 @@ def test_error_too_low_depth(nrows, ncols, num_significant_singular_vals):
     A = make_A(nrows, ncols, num_significant_singular_vals)
     min_depth = 0
     with testing.raises(ValueError, match=""):
-        _ = decomp.bidiag(min_depth - 1, matrix_shape=np.shape(A), materialize=False)
+        alg = decomp.bidiag(min_depth - 1, materialize=False)
+        _ = alg(lambda v: A @ v, lambda v: A.T @ v, A[0])
 
 
 @testing.parametrize("nrows", [15])
@@ -81,7 +83,7 @@ def test_no_error_zero_depth(nrows, ncols, num_significant_singular_vals):
     def vA(v):
         return v @ A
 
-    algorithm = decomp.bidiag(0, matrix_shape=np.shape(A), materialize=False)
+    algorithm = decomp.bidiag(0, materialize=False)
     (U, V), (d_m, e_m), res, ln = algorithm(Av, vA, v0)
 
     assert np.shape(U) == (nrows, 1)

--- a/tests/test_eig/test_svd_partial.py
+++ b/tests/test_eig/test_svd_partial.py
@@ -34,7 +34,7 @@ def test_equal_to_linalg_svd(A):
 
     v0 = np.ones((ncols,))
     v0 /= linalg.vector_norm(v0)
-    U, S, Vt = eig.svd_partial(v0, depth, Av, vA, matrix_shape=np.shape(A))
+    U, S, Vt = eig.svd_partial(v0, depth, Av, vA)
     U_, S_, Vt_ = linalg.svd(A, full_matrices=False)
 
     tols_decomp = {"atol": 1e-5, "rtol": 1e-5}

--- a/tests/test_funm/test_integrand_funm_product_schatten_norm.py
+++ b/tests/test_funm/test_integrand_funm_product_schatten_norm.py
@@ -1,6 +1,6 @@
 """Test stochastic Lanczos quadrature for Schatten-p-norms."""
 
-from matfree import funm, stochtrace, test_util
+from matfree import decomp, funm, stochtrace, test_util
 from matfree.backend import linalg, np, prng, testing
 
 
@@ -27,7 +27,8 @@ def test_schatten_norm(A, order, power):
     _, ncols = np.shape(A)
     args_like = np.ones((ncols,), dtype=float)
     sampler = stochtrace.sampler_normal(args_like, num=500)
-    integrand = funm.integrand_funm_product_schatten_norm(power, order)
+    bidiag = decomp.bidiag(order)
+    integrand = funm.integrand_funm_product_schatten_norm(power, bidiag)
     estimate = stochtrace.estimator(integrand, sampler)
 
     key = prng.prng_key(1)

--- a/tests/test_funm/test_integrand_funm_product_schatten_norm.py
+++ b/tests/test_funm/test_integrand_funm_product_schatten_norm.py
@@ -4,8 +4,7 @@ from matfree import decomp, funm, stochtrace, test_util
 from matfree.backend import linalg, np, prng, testing
 
 
-@testing.fixture()
-def A(nrows, ncols, num_significant_singular_vals):
+def make_A(nrows, ncols, num_significant_singular_vals):
     """Make a positive definite matrix with certain spectrum."""
     # 'Invent' a spectrum. Use the number of pre-defined eigenvalues.
     n = min(nrows, ncols)
@@ -19,8 +18,9 @@ def A(nrows, ncols, num_significant_singular_vals):
 @testing.parametrize("num_significant_singular_vals", [30])
 @testing.parametrize("order", [20])
 @testing.parametrize("power", [1, 2, 5])
-def test_schatten_norm(A, order, power):
+def test_schatten_norm(nrows, ncols, num_significant_singular_vals, order, power):
     """Assert that the Schatten norm is accurate."""
+    A = make_A(nrows, ncols, num_significant_singular_vals)
     _, s, _ = linalg.svd(A, full_matrices=False)
     expected = np.sum(s**power)
 

--- a/tutorials/1_log_determinants.py
+++ b/tutorials/1_log_determinants.py
@@ -59,7 +59,8 @@ def vecmat_l(x):
 
 
 order = 3
-problem = funm.integrand_funm_product_logdet(order)
+bidiag = decomp.bidiag(order)
+problem = funm.integrand_funm_product_logdet(bidiag)
 sampler = stochtrace.sampler_normal(x_like, num=1_000)
 estimator = stochtrace.estimator(problem, sampler=sampler)
 logdet = estimator((matvec_r, vecmat_l), jax.random.PRNGKey(1))


### PR DESCRIPTION
Why? To allow a user to choose between different kinds of (e.g.) reorthogonalisation.

Thus, this PR resolves #196.

As a side-result, bidiag() does not need information about the matrix shape anymore and reads it off the inputs at execution time instead.