### PR TITLE
Configure automatically generated release notes to organize how PRs are displayed

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+---
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels: [breaking-change]
+    - title: New Features
+      labels: [enhancement]
+    - title: Improvements to the Documentation
+      labels: [documentation]
+    - title: Other Changes
+      labels: ['*']


### PR DESCRIPTION
Via [this tutorial](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes).