### PR TITLE
Automatically implement vector matrix products with `jax.vjp`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -11,7 +11,7 @@ repos:
       - id: check-merge-conflict
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.4
+    rev: v0.8.6
     hooks:
       # Run the linter.
       - id: ruff
@@ -19,7 +19,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
+    rev: v1.14.1
     hooks:
       - id: mypy
         args:

--- a/matfree/eig.py
+++ b/matfree/eig.py
@@ -6,7 +6,7 @@ from matfree.backend.typing import Array, Callable
 
 
 # todo: why does this function not return a callable?
-def svd_partial(v0: Array, depth: int, Av: Callable, vA: Callable):
+def svd_partial(v0: Array, depth: int, Av: Callable):
     """Partial singular value decomposition.
 
     Combines bidiagonalisation with full reorthogonalisation
@@ -27,7 +27,7 @@ def svd_partial(v0: Array, depth: int, Av: Callable, vA: Callable):
     """
     # Factorise the matrix
     algorithm = decomp.bidiag(depth, materialize=True)
-    (u, v), B, *_ = algorithm(Av, vA, v0)
+    (u, v), B, *_ = algorithm(Av, v0)
 
     # Compute SVD of factorisation
     U, S, Vt = linalg.svd(B, full_matrices=False)

--- a/tests/test_decomp/test_bidiag.py
+++ b/tests/test_decomp/test_bidiag.py
@@ -32,7 +32,7 @@ def test_bidiag_decomposition_is_satisfied(
         return v @ A
 
     algorithm = decomp.bidiag(order, materialize=True)
-    (U, V), B, res, ln = algorithm(Av, vA, v0)
+    (U, V), B, res, ln = algorithm(Av, v0)
 
     test_util.assert_columns_orthonormal(U)
     test_util.assert_columns_orthonormal(V)
@@ -51,9 +51,9 @@ def test_error_too_high_depth(nrows, ncols, num_significant_singular_vals):
     A = make_A(nrows, ncols, num_significant_singular_vals)
     max_depth = min(nrows, ncols) - 1
 
-    with testing.raises(ValueError, match=""):
+    with testing.raises(ValueError, match="exceeds"):
         alg = decomp.bidiag(max_depth + 1, materialize=False)
-        _ = alg(lambda v: A @ v, lambda v: A.T @ v, A[0])
+        _ = alg(lambda v: A @ v, A[0])
 
 
 @testing.parametrize("nrows", [5])
@@ -63,9 +63,9 @@ def test_error_too_low_depth(nrows, ncols, num_significant_singular_vals):
     """Assert that a ValueError is raised when the depth is negative."""
     A = make_A(nrows, ncols, num_significant_singular_vals)
     min_depth = 0
-    with testing.raises(ValueError, match=""):
+    with testing.raises(ValueError, match="exceeds"):
         alg = decomp.bidiag(min_depth - 1, materialize=False)
-        _ = alg(lambda v: A @ v, lambda v: A.T @ v, A[0])
+        _ = alg(lambda v: A @ v, A[0])
 
 
 @testing.parametrize("nrows", [15])
@@ -84,7 +84,7 @@ def test_no_error_zero_depth(nrows, ncols, num_significant_singular_vals):
         return v @ A
 
     algorithm = decomp.bidiag(0, materialize=False)
-    (U, V), (d_m, e_m), res, ln = algorithm(Av, vA, v0)
+    (U, V), (d_m, e_m), res, ln = algorithm(Av, v0)
 
     assert np.shape(U) == (nrows, 1)
     assert np.shape(V) == (ncols, 1)

--- a/tests/test_eig/test_svd_partial.py
+++ b/tests/test_eig/test_svd_partial.py
@@ -29,12 +29,9 @@ def test_equal_to_linalg_svd(A):
     def Av(v):
         return A @ v
 
-    def vA(v):
-        return v @ A
-
     v0 = np.ones((ncols,))
     v0 /= linalg.vector_norm(v0)
-    U, S, Vt = eig.svd_partial(v0, depth, Av, vA)
+    U, S, Vt = eig.svd_partial(v0, depth, Av)
     U_, S_, Vt_ = linalg.svd(A, full_matrices=False)
 
     tols_decomp = {"atol": 1e-5, "rtol": 1e-5}

--- a/tests/test_funm/test_integrand_funm_product_logdet.py
+++ b/tests/test_funm/test_integrand_funm_product_logdet.py
@@ -25,16 +25,13 @@ def test_logdet_product(nrows, ncols, num_significant_singular_vals, order):
     def matvec(x):
         return {"fx": A @ x["fx"]}
 
-    def vecmat(x):
-        return {"fx": x["fx"] @ A}
-
     x_like = {"fx": np.ones((ncols,), dtype=float)}
     fun = stochtrace.sampler_normal(x_like, num=400)
 
     bidiag = decomp.bidiag(order)
     problem = funm.integrand_funm_product_logdet(bidiag)
     estimate = stochtrace.estimator(problem, fun)
-    received = estimate((matvec, vecmat), key)
+    received = estimate(matvec, key)
 
     expected = linalg.slogdet(A.T @ A)[1]
     print_if_assert_fails = ("error", np.abs(received - expected), "target:", expected)
@@ -61,7 +58,7 @@ def test_logdet_product_exact_for_full_order_lanczos(n):
     x = prng.normal(prng.prng_key(seed=1), shape=(n,)) + 1
 
     # Compute v^\top @ log(A) @ v via Lanczos
-    received = integrand((lambda v: A @ v, lambda v: v @ A), x)
+    received = integrand((lambda v: A @ v), x)
 
     # Compute the "true" value of v^\top @ log(A) @ v via eigenvalues
     eigvals, eigvecs = linalg.eigh(A.T @ A)

--- a/tests/test_funm/test_integrand_funm_product_schatten_norm.py
+++ b/tests/test_funm/test_integrand_funm_product_schatten_norm.py
@@ -32,7 +32,7 @@ def test_schatten_norm(nrows, ncols, num_significant_singular_vals, order, power
     estimate = stochtrace.estimator(integrand, sampler)
 
     key = prng.prng_key(1)
-    received = estimate((lambda v: A @ v, lambda v: A.T @ v), key)
+    received = estimate(lambda v: A @ v, key)
 
     print_if_assert_fails = ("error", np.abs(received - expected), "target:", expected)
     assert np.allclose(received, expected, atol=1e-2, rtol=1e-2), print_if_assert_fails

--- a/tutorials/1_log_determinants.py
+++ b/tutorials/1_log_determinants.py
@@ -48,14 +48,9 @@ A += jnp.eye(nrows)
 A /= nrows**2
 
 
-def matvec_r(x):
+def matvec_half(x):
     """Compute a matrix-vector product."""
     return A @ x
-
-
-def vecmat_l(x):
-    """Compute a vector-matrix product."""
-    return x @ A
 
 
 order = 3
@@ -63,9 +58,12 @@ bidiag = decomp.bidiag(order)
 problem = funm.integrand_funm_product_logdet(bidiag)
 sampler = stochtrace.sampler_normal(x_like, num=1_000)
 estimator = stochtrace.estimator(problem, sampler=sampler)
-logdet = estimator((matvec_r, vecmat_l), jax.random.PRNGKey(1))
+logdet = estimator(matvec_half, jax.random.PRNGKey(1))
 print(logdet)
 
+# Internally, Matfree uses JAX's vector-Jacobian products to
+# turn the matrix-vector product into a vector-matrix product.
+#
 # For comparison:
 
 print(jnp.linalg.slogdet(A.T @ A))


### PR DESCRIPTION
Resolves #228.

**This change breaks the current API** because all bidiagonalisation-based algorithms no longer require vector-matrix products to be passed to the decomposition. This includes:

- `decomp.bidiag`
- `eig.svd_partial`
- `funm.integrand_funm_product`

Instead of requiring the vector-Jacobian product, all functions now use `jax.vjp` to turn a matrix-vector product into a vector-matrix product. We don't use `jax.linear_transpose` because the forward pass is required for bidiagonalisation anyway, so we can do evaluation+transposition in a single call to `vjp` instead of a call to, each, forward pass and transposition.


The next version number will reflect the backwards-incompatible change.  