### PR TITLE
Rename all `krylov_depth`-like parameters to `num_matvecs` and ensure consistency between decomps

### DIFF
--- a/matfree/backend/testing.py
+++ b/matfree/backend/testing.py
@@ -17,8 +17,10 @@ def parametrize_with_cases(argnames, /, cases, prefix):
     return pytest_cases.parametrize_with_cases(argnames, cases=cases, prefix=prefix)
 
 
-def check_grads(fun, /, args, *, order, atol, rtol):
-    return jax.test_util.check_grads(fun, args, order=order, atol=atol, rtol=rtol)
+def check_grads(fun, /, args, *, num_matvecs, atol, rtol):
+    return jax.test_util.check_grads(
+        fun, args, num_matvecs=num_matvecs, atol=atol, rtol=rtol
+    )
 
 
 def raises(err, /, match):

--- a/matfree/backend/testing.py
+++ b/matfree/backend/testing.py
@@ -1,6 +1,5 @@
 """Test-utilities."""
 
-import jax.test_util
 import pytest
 import pytest_cases
 
@@ -15,12 +14,6 @@ def parametrize(argnames, argvalues, /):
 
 def parametrize_with_cases(argnames, /, cases, prefix):
     return pytest_cases.parametrize_with_cases(argnames, cases=cases, prefix=prefix)
-
-
-def check_grads(fun, /, args, *, num_matvecs, atol, rtol):
-    return jax.test_util.check_grads(
-        fun, args, num_matvecs=num_matvecs, atol=atol, rtol=rtol
-    )
 
 
 def raises(err, /, match):

--- a/matfree/decomp.py
+++ b/matfree/decomp.py
@@ -597,9 +597,7 @@ def bidiag(num_matvecs: int, /, materialize: bool = True):
         # Complain if the shapes don't match
         max_num_matvecs = min(nrows, ncols) - 1
         if num_matvecs > max_num_matvecs or num_matvecs < 0:
-            msg1 = (
-                f"Parameter num_matvecs={num_matvecs} exceeds the matrix' dimensions. "
-            )
+            msg1 = f"Parameter num_matvecs={num_matvecs} exceeds the matrix' size. "
             msg2 = "Expected: 0 <= num_matvecs <= min(nrows, ncols) - 1"
             msg3 = f"for a matrix with shape {(nrows, ncols)}."
             raise ValueError(msg1 + msg2 + msg3)

--- a/matfree/decomp.py
+++ b/matfree/decomp.py
@@ -28,7 +28,7 @@ class _DecompResult(containers.NamedTuple):
 
 
 def tridiag_sym(
-    krylov_depth: int,
+    num_matvecs: int,
     /,
     *,
     materialize: bool = True,
@@ -65,12 +65,11 @@ def tridiag_sym(
 
     Parameters
     ----------
-    krylov_depth
-        The depth of the Krylov space.
-        Read this as ``number of matrix-vector products''.
+    num_matvecs
+        The number of matrix-vector products aka the depth of the Krylov space.
         The deeper the Krylov space, the more accurate the factorisation tends to be.
         However, the computational complexity increases linearly
-        with the depth of the Krylov space.
+        with the number of matrix-vector products.
     materialize
         The value of this flag indicates whether the tridiagonal matrix
         should be returned in a sparse format (which means, as a tuple of diagonas)
@@ -106,21 +105,21 @@ def tridiag_sym(
     """
     if reortho == "full":
         return _tridiag_reortho_full(
-            krylov_depth, custom_vjp=custom_vjp, materialize=materialize
+            num_matvecs, custom_vjp=custom_vjp, materialize=materialize
         )
     if reortho == "none":
         return _tridiag_reortho_none(
-            krylov_depth, custom_vjp=custom_vjp, materialize=materialize
+            num_matvecs, custom_vjp=custom_vjp, materialize=materialize
         )
 
     msg = f"reortho={reortho} unsupported. Choose eiter {'full', 'none'}."
     raise ValueError(msg)
 
 
-def _tridiag_reortho_full(krylov_depth: int, /, *, custom_vjp: bool, materialize: bool):
+def _tridiag_reortho_full(num_matvecs: int, /, *, custom_vjp: bool, materialize: bool):
     # Implement via Arnoldi to use the reorthogonalised adjoints.
     # The complexity difference is minimal with full reortho.
-    alg = hessenberg(krylov_depth, custom_vjp=custom_vjp, reortho="full")
+    alg = hessenberg(num_matvecs, custom_vjp=custom_vjp, reortho="full")
 
     def estimate(matvec, vec, *params):
         Q, H, v, norm = alg(matvec, vec, *params)
@@ -147,7 +146,7 @@ def _todense_tridiag_sym(diag, off_diag):
     return diag + offdiag1 + offdiag2
 
 
-def _tridiag_reortho_none(krylov_depth: int, /, *, custom_vjp: bool, materialize: bool):
+def _tridiag_reortho_none(num_matvecs: int, /, *, custom_vjp: bool, materialize: bool):
     def estimate(matvec, vec, *params):
         (Q, H), (q, b) = _estimate(matvec, vec, *params)
         v = b * q
@@ -161,7 +160,7 @@ def _tridiag_reortho_none(krylov_depth: int, /, *, custom_vjp: bool, materialize
         )
 
     def _estimate(matvec, vec, *params):
-        *values, _ = _tridiag_forward(matvec, krylov_depth, vec, *params)
+        *values, _ = _tridiag_forward(matvec, num_matvecs, vec, *params)
         return values
 
     def estimate_fwd(matvec, vec, *params):
@@ -200,11 +199,11 @@ def _tridiag_reortho_none(krylov_depth: int, /, *, custom_vjp: bool, materialize
     return estimate
 
 
-def _tridiag_forward(matvec, krylov_depth, vec, *params):
+def _tridiag_forward(matvec, num_matvecs, vec, *params):
     # Pre-allocate
-    vectors = np.zeros((krylov_depth + 1, len(vec)))
-    offdiags = np.zeros((krylov_depth,))
-    diags = np.zeros((krylov_depth,))
+    vectors = np.zeros((num_matvecs + 1, len(vec)))
+    offdiags = np.zeros((num_matvecs,))
+    diags = np.zeros((num_matvecs,))
 
     # Normalize (not all Lanczos implementations do that)
     v0 = vec / linalg.vector_norm(vec)
@@ -223,7 +222,7 @@ def _tridiag_forward(matvec, krylov_depth, vec, *params):
     init = (v1, offdiag, v0), (vectors, diags, offdiags)
     step_fun = func.partial(_tridiag_fwd_step, matvec, params)
     _, (vectors, diags, offdiags) = control_flow.fori_loop(
-        lower=1, upper=krylov_depth, body_fun=step_fun, init_val=init
+        lower=1, upper=num_matvecs, body_fun=step_fun, init_val=init
     )
 
     # Reorganise the outputs
@@ -327,12 +326,7 @@ def _tridiag_adjoint_step(
 
 
 def hessenberg(
-    krylov_depth,
-    /,
-    *,
-    reortho: str,
-    custom_vjp: bool = True,
-    reortho_vjp: str = "match",
+    num_matvecs, /, *, reortho: str, custom_vjp: bool = True, reortho_vjp: str = "match"
 ):
     r"""Construct a **Hessenberg-factorisation** via the Arnoldi iteration.
 
@@ -371,7 +365,7 @@ def hessenberg(
     def _estimate(matvec_convert: Callable, v, *params):
         reortho_ = reortho_vjp if reortho_vjp != "match" else reortho_vjp
         return _hessenberg_forward(
-            matvec_convert, krylov_depth, v, *params, reortho=reortho_
+            matvec_convert, num_matvecs, v, *params, reortho=reortho_
         )
 
     def estimate_fwd(matvec_convert: Callable, v, *params):
@@ -402,13 +396,13 @@ def hessenberg(
     return estimate
 
 
-def _hessenberg_forward(matvec, krylov_depth, v, *params, reortho: str):
-    if krylov_depth < 1 or krylov_depth > len(v):
-        msg = f"Parameter depth {krylov_depth} is outside the expected range"
+def _hessenberg_forward(matvec, num_matvecs, v, *params, reortho: str):
+    if num_matvecs < 1 or num_matvecs > len(v):
+        msg = f"Parameter num_matvecs {num_matvecs} is outside the expected range"
         raise ValueError(msg)
 
     # Initialise the variables
-    (n,), k = np.shape(v), krylov_depth
+    (n,), k = np.shape(v), num_matvecs
     Q = np.zeros((n, k), dtype=v.dtype)
     H = np.zeros((k, k), dtype=v.dtype)
     initlength = np.sqrt(linalg.inner(v, v))
@@ -453,7 +447,7 @@ def _hessenberg_forward_step(Q, H, v, length, matvec, *params, idx, reortho: str
 
 def _hessenberg_adjoint(matvec, *params, Q, H, r, c, dQ, dH, dr, dc, reortho: str):
     # Extract the matrix shapes from Q
-    _, krylov_depth = np.shape(Q)
+    _, num_matvecs = np.shape(Q)
 
     # Prepare a bunch of auxiliary matrices
 
@@ -461,8 +455,8 @@ def _hessenberg_adjoint(matvec, *params, Q, H, r, c, dQ, dH, dr, dc, reortho: st
         m_tril = np.tril(m)
         return m_tril - 0.5 * _extract_diag(m_tril)
 
-    e_1, e_K = np.eye(krylov_depth)[[0, -1], :]
-    lower_mask = lower(np.ones((krylov_depth, krylov_depth)))
+    e_1, e_K = np.eye(num_matvecs)[[0, -1], :]
+    lower_mask = lower(np.ones((num_matvecs, num_matvecs)))
 
     # Initialise
     eta = dH @ e_K - Q.T @ dr
@@ -478,7 +472,7 @@ def _hessenberg_adjoint(matvec, *params, Q, H, r, c, dQ, dH, dr, dc, reortho: st
     # Prepare reorthogonalisation:
     P = Q.T
     ps = dH.T
-    ps_mask = np.tril(np.ones((krylov_depth, krylov_depth)), 1)
+    ps_mask = np.tril(np.ones((num_matvecs, num_matvecs)), 1)
 
     # Loop over those values
     indices = np.arange(0, len(H), step=1)
@@ -573,7 +567,7 @@ def _extract_diag(x, offset=0):
     return linalg.diagonal_matrix(diag, offset=offset)
 
 
-def bidiag(depth: int, /, materialize: bool = True):
+def bidiag(num_matvecs: int, /, materialize: bool = True):
     """Construct an implementation of **bidiagonalisation**.
 
     Uses pre-allocation and full reorthogonalisation.
@@ -601,10 +595,12 @@ def bidiag(depth: int, /, materialize: bool = True):
         (nrows,) = np.shape(w0_like)
 
         # Complain if the shapes don't match
-        max_depth = min(nrows, ncols) - 1
-        if depth > max_depth or depth < 0:
-            msg1 = f"Depth {depth} exceeds the matrix' dimensions. "
-            msg2 = f"Expected: 0 <= depth <= min(nrows, ncols) - 1 = {max_depth} "
+        max_num_matvecs = min(nrows, ncols) - 1
+        if num_matvecs > max_num_matvecs or num_matvecs < 0:
+            msg1 = (
+                f"Parameter num_matvecs={num_matvecs} exceeds the matrix' dimensions. "
+            )
+            msg2 = "Expected: 0 <= num_matvecs <= min(nrows, ncols) - 1"
             msg3 = f"for a matrix with shape {(nrows, ncols)}."
             raise ValueError(msg1 + msg2 + msg3)
 
@@ -615,7 +611,7 @@ def bidiag(depth: int, /, materialize: bool = True):
             return step(Av, s, *parameters)
 
         result = control_flow.fori_loop(
-            0, depth + 1, body_fun=body_fun, init_val=init_val
+            0, num_matvecs + 1, body_fun=body_fun, init_val=init_val
         )
         uk_all_T, J, vk_all, (beta, vk) = extract(result)
         return _DecompResult(
@@ -635,10 +631,10 @@ def bidiag(depth: int, /, materialize: bool = True):
         vk: Array
 
     def init(init_vec: Array, *, nrows, ncols) -> State:
-        alphas = np.zeros((depth + 1,))
-        betas = np.zeros((depth + 1,))
-        Us = np.zeros((depth + 1, nrows))
-        Vs = np.zeros((depth + 1, ncols))
+        alphas = np.zeros((num_matvecs + 1,))
+        betas = np.zeros((num_matvecs + 1,))
+        Us = np.zeros((num_matvecs + 1, nrows))
+        Vs = np.zeros((num_matvecs + 1, ncols))
         v0, _ = _normalise(init_vec)
         return State(0, Us, Vs, alphas, betas, np.zeros(()), v0)
 

--- a/matfree/eig.py
+++ b/matfree/eig.py
@@ -6,7 +6,7 @@ from matfree.backend.typing import Array, Callable
 
 
 # todo: why does this function not return a callable?
-def svd_partial(v0: Array, depth: int, Av: Callable):
+def svd_partial(v0: Array, num_matvecs: int, Av: Callable):
     """Partial singular value decomposition.
 
     Combines bidiagonalisation with full reorthogonalisation
@@ -16,17 +16,16 @@ def svd_partial(v0: Array, depth: int, Av: Callable):
     ----------
     v0:
         Initial vector for Golub-Kahan-Lanczos bidiagonalisation.
-    depth:
-        Depth of the Krylov space constructed by Golub-Kahan-Lanczos bidiagonalisation.
-        Choosing `depth = min(nrows, ncols) - 1` would yield behaviour similar to
+    num_matvecs:
+        Number of matrix-vector products aka the depth of the Krylov space
+        constructed by Golub-Kahan-Lanczos bidiagonalisation.
+        Choosing `num_matvecs = min(nrows, ncols) - 1` would yield behaviour similar to
         e.g. `np.linalg.svd`.
     Av:
         Matrix-vector product function.
-    vA:
-        Vector-matrix product function.
     """
     # Factorise the matrix
-    algorithm = decomp.bidiag(depth, materialize=True)
+    algorithm = decomp.bidiag(num_matvecs, materialize=True)
     (u, v), B, *_ = algorithm(Av, v0)
 
     # Compute SVD of factorisation

--- a/matfree/funm.py
+++ b/matfree/funm.py
@@ -41,7 +41,7 @@ from matfree.backend import containers, control_flow, func, linalg, np, tree_uti
 from matfree.backend.typing import Array, Callable
 
 
-def funm_chebyshev(matfun: Callable, order: int, matvec: Callable, /) -> Callable:
+def funm_chebyshev(matfun: Callable, num_matvecs: int, matvec: Callable, /) -> Callable:
     """Compute a matrix-function-vector product via Chebyshev's algorithm.
 
     This function assumes that the **spectrum of the matrix-vector product
@@ -50,7 +50,7 @@ def funm_chebyshev(matfun: Callable, order: int, matvec: Callable, /) -> Callabl
     transform the matrix-vector product and the matrix-function accordingly.
     """
     # Construct nodes
-    nodes = _chebyshev_nodes(order)
+    nodes = _chebyshev_nodes(num_matvecs)
     fx_nodes = matfun(nodes)
 
     class _ChebyshevState(containers.NamedTuple):
@@ -88,7 +88,7 @@ def funm_chebyshev(matfun: Callable, order: int, matvec: Callable, /) -> Callabl
     def extract_func(val: _ChebyshevState):
         return val.interpolation
 
-    alg = (0, order - 1), init_func, recursion_func, extract_func
+    alg = (0, num_matvecs - 1), init_func, recursion_func, extract_func
     return _funm_polyexpand(alg)
 
 

--- a/tests/test_decomp/test_bidiag.py
+++ b/tests/test_decomp/test_bidiag.py
@@ -46,33 +46,33 @@ def test_bidiag_decomposition_is_satisfied(
 @testing.parametrize("nrows", [5])
 @testing.parametrize("ncols", [3])
 @testing.parametrize("num_significant_singular_vals", [3])
-def test_error_too_high_depth(nrows, ncols, num_significant_singular_vals):
-    """Assert that a ValueError is raised when the depth exceeds the matrix size."""
+def test_error_too_high_num_matvecs(nrows, ncols, num_significant_singular_vals):
+    """Assert a ValueError is raised when the num_matvecs exceeds the matrix size."""
     A = make_A(nrows, ncols, num_significant_singular_vals)
-    max_depth = min(nrows, ncols) - 1
+    max_num_matvecs = min(nrows, ncols) - 1
 
     with testing.raises(ValueError, match="exceeds"):
-        alg = decomp.bidiag(max_depth + 1, materialize=False)
+        alg = decomp.bidiag(max_num_matvecs + 1, materialize=False)
         _ = alg(lambda v: A @ v, A[0])
 
 
 @testing.parametrize("nrows", [5])
 @testing.parametrize("ncols", [3])
 @testing.parametrize("num_significant_singular_vals", [3])
-def test_error_too_low_depth(nrows, ncols, num_significant_singular_vals):
-    """Assert that a ValueError is raised when the depth is negative."""
+def test_error_too_low_num_matvecs(nrows, ncols, num_significant_singular_vals):
+    """Assert that a ValueError is raised when the num_matvecs is negative."""
     A = make_A(nrows, ncols, num_significant_singular_vals)
-    min_depth = 0
+    min_num_matvecs = 0
     with testing.raises(ValueError, match="exceeds"):
-        alg = decomp.bidiag(min_depth - 1, materialize=False)
+        alg = decomp.bidiag(min_num_matvecs - 1, materialize=False)
         _ = alg(lambda v: A @ v, A[0])
 
 
 @testing.parametrize("nrows", [15])
 @testing.parametrize("ncols", [3])
 @testing.parametrize("num_significant_singular_vals", [3])
-def test_no_error_zero_depth(nrows, ncols, num_significant_singular_vals):
-    """Assert the corner case of zero-depth does not raise an error."""
+def test_no_error_zero_num_matvecs(nrows, ncols, num_significant_singular_vals):
+    """Assert the corner case of zero-num_matvecs does not raise an error."""
     A = make_A(nrows, ncols, num_significant_singular_vals)
     key = prng.prng_key(1)
     v0 = prng.normal(key, shape=(ncols,))

--- a/tests/test_decomp/test_bidiag.py
+++ b/tests/test_decomp/test_bidiag.py
@@ -25,70 +25,13 @@ def test_bidiag_decomposition_is_satisfied(
     key = prng.prng_key(1)
     v0 = prng.normal(key, shape=(ncols,))
 
-    def Av(v):
-        return A @ v
-
-    def vA(v):
-        return v @ A
-
     algorithm = decomp.bidiag(num_matvecs, materialize=True)
-    (U, V), B, res, ln = algorithm(Av, v0)
+    (U, V), B, res, ln = algorithm(lambda v: A @ v, v0)
 
     test_util.assert_columns_orthonormal(U)
     test_util.assert_columns_orthonormal(V)
 
-    em = np.eye(num_matvecs + 1)[:, -1]
+    em = np.eye(num_matvecs)[:, -1]
     test_util.assert_allclose(A @ V, U @ B)
     test_util.assert_allclose(A.T @ U, V @ B.T + linalg.outer(res, em))
     test_util.assert_allclose(1.0 / linalg.vector_norm(v0), ln)
-
-
-@testing.parametrize("nrows", [5])
-@testing.parametrize("ncols", [3])
-@testing.parametrize("num_significant_singular_vals", [3])
-def test_error_too_high_num_matvecs(nrows, ncols, num_significant_singular_vals):
-    """Assert a ValueError is raised when the num_matvecs exceeds the matrix size."""
-    A = make_A(nrows, ncols, num_significant_singular_vals)
-    max_num_matvecs = min(nrows, ncols) - 1
-
-    with testing.raises(ValueError, match="exceeds"):
-        alg = decomp.bidiag(max_num_matvecs + 1, materialize=False)
-        _ = alg(lambda v: A @ v, A[0])
-
-
-@testing.parametrize("nrows", [5])
-@testing.parametrize("ncols", [3])
-@testing.parametrize("num_significant_singular_vals", [3])
-def test_error_too_low_num_matvecs(nrows, ncols, num_significant_singular_vals):
-    """Assert that a ValueError is raised when the num_matvecs is negative."""
-    A = make_A(nrows, ncols, num_significant_singular_vals)
-    min_num_matvecs = 0
-    with testing.raises(ValueError, match="exceeds"):
-        alg = decomp.bidiag(min_num_matvecs - 1, materialize=False)
-        _ = alg(lambda v: A @ v, A[0])
-
-
-@testing.parametrize("nrows", [15])
-@testing.parametrize("ncols", [3])
-@testing.parametrize("num_significant_singular_vals", [3])
-def test_no_error_zero_num_matvecs(nrows, ncols, num_significant_singular_vals):
-    """Assert the corner case of zero-num_matvecs does not raise an error."""
-    A = make_A(nrows, ncols, num_significant_singular_vals)
-    key = prng.prng_key(1)
-    v0 = prng.normal(key, shape=(ncols,))
-
-    def Av(v):
-        return A @ v
-
-    def vA(v):
-        return v @ A
-
-    algorithm = decomp.bidiag(0, materialize=False)
-    (U, V), (d_m, e_m), res, ln = algorithm(Av, v0)
-
-    assert np.shape(U) == (nrows, 1)
-    assert np.shape(V) == (ncols, 1)
-    assert np.shape(d_m) == (1,)
-    assert np.shape(e_m) == (0,)
-    assert np.shape(res) == (ncols,)
-    assert np.shape(ln) == ()

--- a/tests/test_decomp/test_bidiag.py
+++ b/tests/test_decomp/test_bidiag.py
@@ -16,9 +16,9 @@ def make_A(nrows, ncols, num_significant_singular_vals):
 @testing.parametrize("nrows", [50])
 @testing.parametrize("ncols", [49])
 @testing.parametrize("num_significant_singular_vals", [4])
-@testing.parametrize("order", [6])  # ~1.5 * num_significant_eigvals
+@testing.parametrize("num_matvecs", [6])  # ~1.5 * num_significant_eigvals
 def test_bidiag_decomposition_is_satisfied(
-    nrows, ncols, num_significant_singular_vals, order
+    nrows, ncols, num_significant_singular_vals, num_matvecs
 ):
     """Test that Lanczos tridiagonalisation yields an orthogonal-tridiagonal decomp."""
     A = make_A(nrows, ncols, num_significant_singular_vals)
@@ -31,13 +31,13 @@ def test_bidiag_decomposition_is_satisfied(
     def vA(v):
         return v @ A
 
-    algorithm = decomp.bidiag(order, materialize=True)
+    algorithm = decomp.bidiag(num_matvecs, materialize=True)
     (U, V), B, res, ln = algorithm(Av, v0)
 
     test_util.assert_columns_orthonormal(U)
     test_util.assert_columns_orthonormal(V)
 
-    em = np.eye(order + 1)[:, -1]
+    em = np.eye(num_matvecs + 1)[:, -1]
     test_util.assert_allclose(A @ V, U @ B)
     test_util.assert_allclose(A.T @ U, V @ B.T + linalg.outer(res, em))
     test_util.assert_allclose(1.0 / linalg.vector_norm(v0), ln)

--- a/tests/test_decomp/test_consistency.py
+++ b/tests/test_decomp/test_consistency.py
@@ -1,0 +1,63 @@
+"""Ensure that bidiag, tridiag, etc. have consistent signatures."""
+
+from matfree import decomp
+from matfree.backend import np, prng, testing, tree_util
+
+
+def case_method_bidiag():
+    return decomp.bidiag
+
+
+def case_method_tridiag_sym():
+    return lambda n: decomp.tridiag_sym(n, reortho="none")
+
+
+def case_method_tridiag_sym_reortho():
+    return lambda n: decomp.tridiag_sym(n, reortho="full")
+
+
+def case_method_hessenberg():
+    return lambda n: decomp.hessenberg(n, reortho="none")
+
+
+def case_method_hessenberg_reortho():
+    return lambda n: decomp.hessenberg(n, reortho="full")
+
+
+@testing.parametrize("nrows", [13])
+@testing.parametrize("num_matvecs", [6, 13, 0])
+@testing.parametrize_with_cases("method", cases=".", prefix="case_method_")
+def test_output_shape_as_expected(nrows, num_matvecs, method):
+    """Test that all factorisation methods yield consistent output shapes."""
+    key = prng.prng_key(1)
+    key1, key2 = prng.split(key, num=2)
+    A = prng.normal(key1, shape=(nrows, nrows))
+    v0 = prng.normal(key2, shape=(nrows,))
+
+    algorithm = method(num_matvecs)
+    Us, B, res, ln = algorithm(lambda v: A @ v, v0)
+
+    # Normalise the Us to always have a list
+    Us = tree_util.tree_leaves(Us)
+
+    for U in Us:
+        assert np.shape(U) == (nrows, num_matvecs)
+
+    assert np.shape(B) == (num_matvecs, num_matvecs)
+    assert np.shape(res) == (nrows,)
+    assert np.shape(ln) == ()
+
+
+@testing.parametrize("nrows", [13])
+@testing.parametrize("num_matvecs", [-1, 14])  # 0 and 13 must work (see above)
+@testing.parametrize_with_cases("method", cases=".", prefix="case_method_")
+def test_value_error_for_unusual_num_matvecs(nrows, num_matvecs, method):
+    """Assert a ValueError is raised when the num_matvecs exceeds the matrix size."""
+    key = prng.prng_key(1)
+    key1, key2 = prng.split(key, num=2)
+    A = prng.normal(key1, shape=(nrows, nrows))
+    v0 = prng.normal(key2, shape=(nrows,))
+
+    with testing.raises(ValueError, match="exceeds"):
+        alg = method(num_matvecs)
+        _ = alg(lambda v, p: p @ v, v0, A)

--- a/tests/test_decomp/test_hessenberg.py
+++ b/tests/test_decomp/test_hessenberg.py
@@ -5,7 +5,7 @@ from matfree.backend import linalg, np, prng, testing
 
 
 @testing.parametrize("nrows", [10])
-@testing.parametrize("num_matvecs", [1, 5, 10])
+@testing.parametrize("num_matvecs", [0, 5, 9])
 @testing.parametrize("reortho", ["none", "full"])
 @testing.parametrize("dtype", [float])
 def test_decomposition_is_satisfied(nrows, num_matvecs, reortho, dtype):
@@ -27,11 +27,13 @@ def test_decomposition_is_satisfied(nrows, num_matvecs, reortho, dtype):
     e0, ek = np.eye(num_matvecs)[[0, -1], :]
     test_util.assert_allclose(A @ Q - Q @ H - linalg.outer(r, ek), 0.0)
     test_util.assert_allclose(Q.T.conj() @ Q - np.eye(num_matvecs), 0.0)
-    test_util.assert_allclose(Q @ e0, c * v)
+
+    if num_matvecs > 0:
+        test_util.assert_allclose(Q @ e0, c * v)
 
 
 @testing.parametrize("nrows", [10])
-@testing.parametrize("num_matvecs", [1, 5, 10])
+@testing.parametrize("num_matvecs", [5, 9])
 @testing.parametrize("reortho", ["full"])
 def test_reorthogonalisation_improves_the_estimate(nrows, num_matvecs, reortho):
     # Create an ill-conditioned test-matrix (that requires reortho=True)
@@ -53,18 +55,6 @@ def test_reorthogonalisation_improves_the_estimate(nrows, num_matvecs, reortho):
     test_util.assert_allclose(A @ Q - Q @ H - linalg.outer(r, ek), 0.0)
     test_util.assert_allclose(Q.T @ Q - np.eye(num_matvecs), 0.0)
     test_util.assert_allclose(Q @ e0, c * v)
-
-
-def test_raises_error_for_wrong_num_matvecs_too_small():
-    algorithm = decomp.hessenberg(0, reortho="none")
-    with testing.raises(ValueError, match="num_matvecs"):
-        _ = algorithm(lambda s: s, np.ones((2,)))
-
-
-def test_raises_error_for_wrong_num_matvecs_too_high():
-    algorithm = decomp.hessenberg(3, reortho="none")
-    with testing.raises(ValueError, match="num_matvecs"):
-        _ = algorithm(lambda s: s, np.ones((2,)))
 
 
 @testing.parametrize("reortho_wrong", [True, "full_with_sparsity", "None"])

--- a/tests/test_decomp/test_hessenberg.py
+++ b/tests/test_decomp/test_hessenberg.py
@@ -5,65 +5,65 @@ from matfree.backend import linalg, np, prng, testing
 
 
 @testing.parametrize("nrows", [10])
-@testing.parametrize("krylov_depth", [1, 5, 10])
+@testing.parametrize("num_matvecs", [1, 5, 10])
 @testing.parametrize("reortho", ["none", "full"])
 @testing.parametrize("dtype", [float])
-def test_decomposition_is_satisfied(nrows, krylov_depth, reortho, dtype):
+def test_decomposition_is_satisfied(nrows, num_matvecs, reortho, dtype):
     # Create a well-conditioned test-matrix
     A = prng.normal(prng.prng_key(1), shape=(nrows, nrows), dtype=dtype)
     v = prng.normal(prng.prng_key(2), shape=(nrows,), dtype=dtype)
 
     # Decompose
-    algorithm = decomp.hessenberg(krylov_depth, reortho=reortho)
+    algorithm = decomp.hessenberg(num_matvecs, reortho=reortho)
     Q, H, r, c = algorithm(lambda s, p: p @ s, v, A)
 
     # Assert shapes
-    assert Q.shape == (nrows, krylov_depth)
-    assert H.shape == (krylov_depth, krylov_depth)
+    assert Q.shape == (nrows, num_matvecs)
+    assert H.shape == (num_matvecs, num_matvecs)
     assert r.shape == (nrows,)
     assert c.shape == ()
 
     # Test the decompositions
-    e0, ek = np.eye(krylov_depth)[[0, -1], :]
+    e0, ek = np.eye(num_matvecs)[[0, -1], :]
     test_util.assert_allclose(A @ Q - Q @ H - linalg.outer(r, ek), 0.0)
-    test_util.assert_allclose(Q.T.conj() @ Q - np.eye(krylov_depth), 0.0)
+    test_util.assert_allclose(Q.T.conj() @ Q - np.eye(num_matvecs), 0.0)
     test_util.assert_allclose(Q @ e0, c * v)
 
 
 @testing.parametrize("nrows", [10])
-@testing.parametrize("krylov_depth", [1, 5, 10])
+@testing.parametrize("num_matvecs", [1, 5, 10])
 @testing.parametrize("reortho", ["full"])
-def test_reorthogonalisation_improves_the_estimate(nrows, krylov_depth, reortho):
+def test_reorthogonalisation_improves_the_estimate(nrows, num_matvecs, reortho):
     # Create an ill-conditioned test-matrix (that requires reortho=True)
     A = linalg.hilbert(nrows)
     v = prng.normal(prng.prng_key(2), shape=(nrows,))
 
     # Decompose
-    algorithm = decomp.hessenberg(krylov_depth, reortho=reortho)
+    algorithm = decomp.hessenberg(num_matvecs, reortho=reortho)
     Q, H, r, c = algorithm(lambda s, p: p @ s, v, A)
 
     # Assert shapes
-    assert Q.shape == (nrows, krylov_depth)
-    assert H.shape == (krylov_depth, krylov_depth)
+    assert Q.shape == (nrows, num_matvecs)
+    assert H.shape == (num_matvecs, num_matvecs)
     assert r.shape == (nrows,)
     assert c.shape == ()
 
     # Test the decompositions
-    e0, ek = np.eye(krylov_depth)[[0, -1], :]
+    e0, ek = np.eye(num_matvecs)[[0, -1], :]
     test_util.assert_allclose(A @ Q - Q @ H - linalg.outer(r, ek), 0.0)
-    test_util.assert_allclose(Q.T @ Q - np.eye(krylov_depth), 0.0)
+    test_util.assert_allclose(Q.T @ Q - np.eye(num_matvecs), 0.0)
     test_util.assert_allclose(Q @ e0, c * v)
 
 
-def test_raises_error_for_wrong_depth_too_small():
+def test_raises_error_for_wrong_num_matvecs_too_small():
     algorithm = decomp.hessenberg(0, reortho="none")
-    with testing.raises(ValueError, match="depth"):
+    with testing.raises(ValueError, match="num_matvecs"):
         _ = algorithm(lambda s: s, np.ones((2,)))
 
 
-def test_raises_error_for_wrong_depth_too_high():
+def test_raises_error_for_wrong_num_matvecs_too_high():
     algorithm = decomp.hessenberg(3, reortho="none")
-    with testing.raises(ValueError, match="depth"):
+    with testing.raises(ValueError, match="num_matvecs"):
         _ = algorithm(lambda s: s, np.ones((2,)))
 
 

--- a/tests/test_decomp/test_hessenberg_adjoint.py
+++ b/tests/test_decomp/test_hessenberg_adjoint.py
@@ -3,21 +3,19 @@ from matfree.backend import config, func, linalg, np, prng, testing
 
 
 @testing.parametrize("nrows", [3])
-@testing.parametrize("krylov_depth", [2])
+@testing.parametrize("num_matvecs", [2])
 @testing.parametrize("reortho", ["none", "full"])
 @testing.parametrize("dtype", [float])
-def test_adjoint_matches_jax_dot_vjp(nrows, krylov_depth, reortho, dtype):
+def test_adjoint_matches_jax_dot_vjp(nrows, num_matvecs, reortho, dtype):
     # Create a matrix and a direction as a test-case
     A = prng.normal(prng.prng_key(1), shape=(nrows, nrows), dtype=dtype)
     v = prng.normal(prng.prng_key(2), shape=(nrows,), dtype=dtype)
 
     # Set up the algorithms
     algorithm_autodiff = decomp.hessenberg(
-        krylov_depth, reortho=reortho, custom_vjp=False
+        num_matvecs, reortho=reortho, custom_vjp=False
     )
-    algorithm_adjoint = decomp.hessenberg(
-        krylov_depth, reortho=reortho, custom_vjp=True
-    )
+    algorithm_adjoint = decomp.hessenberg(num_matvecs, reortho=reortho, custom_vjp=True)
 
     # Forward pass
     algorithm_autodiff = func.partial(algorithm_autodiff, lambda s, p: p @ s)
@@ -42,10 +40,10 @@ def test_adjoint_matches_jax_dot_vjp(nrows, krylov_depth, reortho, dtype):
 
 
 @testing.parametrize("nrows", [15])
-@testing.parametrize("krylov_depth", [10])
+@testing.parametrize("num_matvecs", [10])
 @testing.parametrize("reortho", ["full"])
 def test_adjoint_matches_jax_dot_vjp_hilbert_matrix_and_full_reortho(
-    nrows, krylov_depth, reortho
+    nrows, num_matvecs, reortho
 ):
     config.update("jax_enable_x64", True)
 
@@ -58,11 +56,9 @@ def test_adjoint_matches_jax_dot_vjp_hilbert_matrix_and_full_reortho(
 
     # Set up the algorithms
     algorithm_autodiff = decomp.hessenberg(
-        krylov_depth, reortho=reortho, custom_vjp=False
+        num_matvecs, reortho=reortho, custom_vjp=False
     )
-    algorithm_adjoint = decomp.hessenberg(
-        krylov_depth, reortho=reortho, custom_vjp=True
-    )
+    algorithm_adjoint = decomp.hessenberg(num_matvecs, reortho=reortho, custom_vjp=True)
 
     # Forward pass
     algorithm_autodiff = func.partial(algorithm_autodiff, matvec)

--- a/tests/test_decomp/test_tridiag_sym.py
+++ b/tests/test_decomp/test_tridiag_sym.py
@@ -16,7 +16,7 @@ def test_full_rank_reconstruction_is_exact(reortho, ndim):
     algorithm = decomp.tridiag_sym(ndim, reortho=reortho, materialize=True)
     Q, T, *_ = algorithm(lambda s, p: p @ s, vector, matrix)
 
-    # Reconstruct the original matrix from the full-order approximation
+    # Reconstruct the original matrix from the full-num_matvecs approximation
     matrix_reconstructed = Q @ T @ Q.T
 
     if reortho == "full":

--- a/tests/test_decomp/test_tridiag_sym.py
+++ b/tests/test_decomp/test_tridiag_sym.py
@@ -34,19 +34,19 @@ def test_full_rank_reconstruction_is_exact(reortho, ndim):
 
 # anything 0 <= k < n works; k=n is full reconstruction
 # and the (q, b) values become meaningless
-@testing.parametrize("krylov_depth", [1, 5, 11])
+@testing.parametrize("num_matvecs", [1, 5, 11])
 @testing.parametrize("ndim", [12])
 @testing.parametrize("reortho", ["full", "none"])
-def test_mid_rank_reconstruction_satisfies_decomposition(ndim, krylov_depth, reortho):
+def test_mid_rank_reconstruction_satisfies_decomposition(ndim, num_matvecs, reortho):
     # Set up a test-matrix and an initial vector
     eigvals = np.arange(1.0, 2.0, step=1 / ndim)
     matrix = test_util.symmetric_matrix_from_eigenvalues(eigvals)
     vector = np.flip(np.arange(1.0, 1.0 + len(eigvals)))
 
     # Run Lanczos approximation
-    algorithm = decomp.tridiag_sym(krylov_depth, reortho=reortho, materialize=True)
+    algorithm = decomp.tridiag_sym(num_matvecs, reortho=reortho, materialize=True)
     Q, T, q, _n = algorithm(lambda s, p: p @ s, vector, matrix)
 
     # Verify the decomposition
-    e_K = np.eye(krylov_depth)[-1]
+    e_K = np.eye(num_matvecs)[-1]
     test_util.assert_allclose(matrix @ Q, Q @ T + linalg.outer(q, e_K))

--- a/tests/test_decomp/test_tridiag_sym_adjoint.py
+++ b/tests/test_decomp/test_tridiag_sym_adjoint.py
@@ -5,7 +5,7 @@ from matfree.backend import func, linalg, np, prng, testing, tree_util
 
 
 @testing.parametrize("reortho", ["full", "none"])
-def test_adjoint_vjp_matches_jax_vjp(reortho, n=10, krylov_order=4):
+def test_adjoint_vjp_matches_jax_vjp(reortho, n=10, krylov_num_matvecs=4):
     """Test that the custom VJP yields the same output as autodiff."""
     # Set up a test-matrix
     eigvals = prng.uniform(prng.prng_key(2), shape=(n,)) + 1.0
@@ -24,7 +24,7 @@ def test_adjoint_vjp_matches_jax_vjp(reortho, n=10, krylov_order=4):
     # Construct a vector-to-vector decomposition function
     def decompose(f, *, custom_vjp):
         kwargs = {"reortho": reortho, "custom_vjp": custom_vjp, "materialize": False}
-        algorithm = decomp.tridiag_sym(krylov_order, **kwargs)
+        algorithm = decomp.tridiag_sym(krylov_num_matvecs, **kwargs)
         output = algorithm(matvec, *unflatten(f))
         return tree_util.ravel_pytree(output)[0]
 

--- a/tests/test_eig/test_svd_partial.py
+++ b/tests/test_eig/test_svd_partial.py
@@ -24,7 +24,7 @@ def test_equal_to_linalg_svd(A):
     and the orthogonal matrices should be orthogonal. They are not unique.
     """
     nrows, ncols = np.shape(A)
-    num_matvecs = min(nrows, ncols) - 1
+    num_matvecs = min(nrows, ncols)
 
     def Av(v):
         return A @ v

--- a/tests/test_eig/test_svd_partial.py
+++ b/tests/test_eig/test_svd_partial.py
@@ -24,14 +24,14 @@ def test_equal_to_linalg_svd(A):
     and the orthogonal matrices should be orthogonal. They are not unique.
     """
     nrows, ncols = np.shape(A)
-    depth = min(nrows, ncols) - 1
+    num_matvecs = min(nrows, ncols) - 1
 
     def Av(v):
         return A @ v
 
     v0 = np.ones((ncols,))
     v0 /= linalg.vector_norm(v0)
-    U, S, Vt = eig.svd_partial(v0, depth, Av)
+    U, S, Vt = eig.svd_partial(v0, num_matvecs, Av)
     U_, S_, Vt_ = linalg.svd(A, full_matrices=False)
 
     tols_decomp = {"atol": 1e-5, "rtol": 1e-5}

--- a/tests/test_funm/test_funm_chebyshev.py
+++ b/tests/test_funm/test_funm_chebyshev.py
@@ -26,8 +26,8 @@ def test_funm_chebyshev(n=12):
     expected = log_matrix @ v
 
     # Create an implementation of the Chebyshev-algorithm
-    order = 6
-    matfun_vec = funm.funm_chebyshev(fun, order, matvec)
+    num_matvecs = 6
+    matfun_vec = funm.funm_chebyshev(fun, num_matvecs, matvec)
 
     # Compute the matrix-function vector product
     received = matfun_vec(v, matrix)

--- a/tests/test_funm/test_integrand_funm_product_logdet.py
+++ b/tests/test_funm/test_integrand_funm_product_logdet.py
@@ -16,8 +16,8 @@ def make_A(nrows, ncols, num_significant_singular_vals):
 @testing.parametrize("nrows", [50])
 @testing.parametrize("ncols", [30])
 @testing.parametrize("num_significant_singular_vals", [30])
-@testing.parametrize("order", [20])
-def test_logdet_product(nrows, ncols, num_significant_singular_vals, order):
+@testing.parametrize("num_matvecs", [20])
+def test_logdet_product(nrows, ncols, num_significant_singular_vals, num_matvecs):
     """Assert that logdet_product yields an accurate estimate."""
     A = make_A(nrows, ncols, num_significant_singular_vals)
     key = prng.prng_key(3)
@@ -28,7 +28,7 @@ def test_logdet_product(nrows, ncols, num_significant_singular_vals, order):
     x_like = {"fx": np.ones((ncols,), dtype=float)}
     fun = stochtrace.sampler_normal(x_like, num=400)
 
-    bidiag = decomp.bidiag(order)
+    bidiag = decomp.bidiag(num_matvecs)
     problem = funm.integrand_funm_product_logdet(bidiag)
     estimate = stochtrace.estimator(problem, fun)
     received = estimate(matvec, key)
@@ -41,7 +41,7 @@ def test_logdet_product(nrows, ncols, num_significant_singular_vals, order):
 @testing.parametrize("n", [50])
 # usually: ~1.5 * num_significant_eigvals.
 # But logdet seems to converge sooo much faster.
-def test_logdet_product_exact_for_full_order_lanczos(n):
+def test_logdet_product_exact_for_full_num_matvecs_lanczos(n):
     r"""Computing v^\top f(A^\top @ A) v with max-order Lanczos is exact for _any_ v."""
     # Construct a (numerically nice) matrix
     singular_values = np.sqrt(np.arange(1.0, 1.0 + n, step=1.0))
@@ -49,9 +49,9 @@ def test_logdet_product_exact_for_full_order_lanczos(n):
         singular_values, nrows=n, ncols=n
     )
 
-    # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
-    order = n - 1
-    bidiag = decomp.bidiag(order)
+    # Set up max-num_matvecs Lanczos approximation inside SLQ for the matrix-logarithm
+    num_matvecs = n - 1
+    bidiag = decomp.bidiag(num_matvecs)
     integrand = funm.integrand_funm_product_logdet(bidiag)
 
     # Construct a vector without that does not have expected 2-norm equal to "dim"

--- a/tests/test_funm/test_integrand_funm_product_schatten_norm.py
+++ b/tests/test_funm/test_integrand_funm_product_schatten_norm.py
@@ -16,9 +16,9 @@ def make_A(nrows, ncols, num_significant_singular_vals):
 @testing.parametrize("nrows", [30])
 @testing.parametrize("ncols", [30])
 @testing.parametrize("num_significant_singular_vals", [30])
-@testing.parametrize("order", [20])
+@testing.parametrize("num_matvecs", [20])
 @testing.parametrize("power", [1, 2, 5])
-def test_schatten_norm(nrows, ncols, num_significant_singular_vals, order, power):
+def test_schatten_norm(nrows, ncols, num_significant_singular_vals, num_matvecs, power):
     """Assert that the Schatten norm is accurate."""
     A = make_A(nrows, ncols, num_significant_singular_vals)
     _, s, _ = linalg.svd(A, full_matrices=False)
@@ -27,7 +27,7 @@ def test_schatten_norm(nrows, ncols, num_significant_singular_vals, order, power
     _, ncols = np.shape(A)
     args_like = np.ones((ncols,), dtype=float)
     sampler = stochtrace.sampler_normal(args_like, num=500)
-    bidiag = decomp.bidiag(order)
+    bidiag = decomp.bidiag(num_matvecs)
     integrand = funm.integrand_funm_product_schatten_norm(power, bidiag)
     estimate = stochtrace.estimator(integrand, sampler)
 

--- a/tests/test_funm/test_integrand_funm_sym_logdet.py
+++ b/tests/test_funm/test_integrand_funm_sym_logdet.py
@@ -15,10 +15,10 @@ def make_A(n, num_significant_eigvals):
 
 @testing.parametrize("n", [200])
 @testing.parametrize("num_significant_eigvals", [30])
-@testing.parametrize("order", [10])
+@testing.parametrize("num_matvecs", [10])
 # usually: ~1.5 * num_significant_eigvals.
 # But logdet seems to converge sooo much faster.
-def test_logdet_spd(n, num_significant_eigvals, order):
+def test_logdet_spd(n, num_significant_eigvals, num_matvecs):
     """Assert that the log-determinant estimation matches the true log-determinant."""
     A = make_A(n, num_significant_eigvals)
 
@@ -28,7 +28,7 @@ def test_logdet_spd(n, num_significant_eigvals, order):
     key = prng.prng_key(1)
     args_like = {"fx": np.ones((n,), dtype=float)}
     sampler = stochtrace.sampler_normal(args_like, num=10)
-    tridiag_sym = decomp.tridiag_sym(order, materialize=True)
+    tridiag_sym = decomp.tridiag_sym(num_matvecs, materialize=True)
     integrand = funm.integrand_funm_sym_logdet(tridiag_sym)
     estimate = stochtrace.estimator(integrand, sampler)
     received = estimate(matvec, key)
@@ -41,15 +41,15 @@ def test_logdet_spd(n, num_significant_eigvals, order):
 @testing.parametrize("n", [50])
 # usually: ~1.5 * num_significant_eigvals.
 # But logdet seems to converge sooo much faster.
-def test_logdet_spd_exact_for_full_order_lanczos(n):
+def test_logdet_spd_exact_for_full_num_matvecs_lanczos(n):
     r"""Computing v^\top f(A) v with max-order Lanczos should be exact for _any_ v."""
     # Construct a (numerically nice) matrix
     eigvals = np.arange(1.0, 1.0 + n, step=1.0)
     A = test_util.symmetric_matrix_from_eigenvalues(eigvals)
 
-    # Set up max-order Lanczos approximation inside SLQ for the matrix-logarithm
-    order = n - 1
-    tridiag_sym = decomp.tridiag_sym(order, materialize=True)
+    # Set up max-num_matvecs Lanczos approximation inside SLQ for the matrix-logarithm
+    num_matvecs = n - 1
+    tridiag_sym = decomp.tridiag_sym(num_matvecs, materialize=True)
     integrand = funm.integrand_funm_sym_logdet(tridiag_sym)
 
     # Construct a vector without that does not have expected 2-norm equal to "dim"

--- a/tutorials/1_log_determinants.py
+++ b/tutorials/1_log_determinants.py
@@ -26,8 +26,8 @@ x_like = jnp.ones((nrows,), dtype=float)  # use to determine shapes of vectors
 
 # Estimate log-determinants with stochastic Lanczos quadrature.
 
-order = 3
-tridiag_sym = decomp.tridiag_sym(order)
+num_matvecs = 3
+tridiag_sym = decomp.tridiag_sym(num_matvecs)
 problem = funm.integrand_funm_sym_logdet(tridiag_sym)
 sampler = stochtrace.sampler_normal(x_like, num=1_000)
 estimator = stochtrace.estimator(problem, sampler=sampler)
@@ -53,8 +53,8 @@ def matvec_half(x):
     return A @ x
 
 
-order = 3
-bidiag = decomp.bidiag(order)
+num_matvecs = 3
+bidiag = decomp.bidiag(num_matvecs)
 problem = funm.integrand_funm_product_logdet(bidiag)
 sampler = stochtrace.sampler_normal(x_like, num=1_000)
 estimator = stochtrace.estimator(problem, sampler=sampler)

--- a/tutorials/2_pytree_logdeterminants.py
+++ b/tutorials/2_pytree_logdeterminants.py
@@ -52,8 +52,8 @@ def make_matvec(alpha):
 
 
 matvec = make_matvec(alpha=0.1)
-order = 3
-tridiag_sym = decomp.tridiag_sym(order)
+num_matvecs = 3
+tridiag_sym = decomp.tridiag_sym(num_matvecs)
 integrand = funm.integrand_funm_sym_logdet(tridiag_sym)
 sample_fun = stochtrace.sampler_normal(f0, num=10)
 estimator = stochtrace.estimator(integrand, sampler=sample_fun)

--- a/tutorials/7_matrix_functions.py
+++ b/tutorials/7_matrix_functions.py
@@ -41,8 +41,8 @@ def large_matvec(v):
     return large_matrix @ v
 
 
-krylov_depth = 5
-arnoldi = decomp.hessenberg(krylov_depth, reortho="full")
+num_matvecs = 5
+arnoldi = decomp.hessenberg(num_matvecs, reortho="full")
 dense_funm = funm.dense_funm_pade_exp()
 matfun_vec = funm.funm_arnoldi(dense_funm, arnoldi)
 received = matfun_vec(large_matvec, vector)


### PR DESCRIPTION
Resolves #222.

- Now, this parameter is called 'num_matvecs' everywhere. The main reason for choosing 'num_matvecs' over 'krylov_rank' and so on is that it is easier to understand for everyone unfamiliar with the inner workings of Krylov subspaces. 
It is also less ambiguous because the rank of the Krylov space is typically `num_matvecs + 1` instead of `num_matvecs`, but this is a convention that matfree takes (for code simplicity). Here, too, does the parameter name `num_matvecs` improve clarity.
- All decompositions (bidiag, tridiag_sym, hessenberg) now interpret "num_matvecs" identically which means they yield the same shapes of outputs depending on the values of `num_matvecs`. Previously, that was not the case because bidiagonalisation interpreted the 'order' parameter differently to the other two. **This change is not backwards compatible, but now the return shapes are consistent.**
- All factorisations' behaviours are clarified if `num_matvecs = 0`
- All factorisations come with checks whether `num_matvecs` is inside an acceptable range 