### PR TITLE
Make `eig.svd_partial` batchable

### DIFF
--- a/matfree/eig.py
+++ b/matfree/eig.py
@@ -1,29 +1,28 @@
 """Matrix-free eigenvalue and singular-value analysis."""
 
-from matfree import decomp
 from matfree.backend import linalg
 from matfree.backend.typing import Array, Callable
 
 
-# todo: why does this function not return a callable?
-def svd_partial(num_matvecs: int):
+def svd_partial(bidiag: Callable):
     """Partial singular value decomposition.
 
     Combines bidiagonalisation with a full SVD of the (small) bidiagonal matrix.
 
     Parameters
     ----------
-    num_matvecs:
-        Number of matrix-vector products aka the depth of the Krylov space
-        constructed by Golub-Kahan-Lanczos bidiagonalisation.
-        Choosing `num_matvecs = min(nrows, ncols) - 1` would yield behaviour similar to
-        e.g. `np.linalg.svd`.
+    bidiag:
+        An implementation of bidiagonalisation.
+        For example, the output of
+        [decomp.bidiag][matfree.decomp.bidiag].
+        Note how this function assumes that the bidiagonalisation
+        materialises the bidiagonal matrix.
+
     """
 
     def svd(Av: Callable, v0: Array):
         # Factorise the matrix
-        algorithm = decomp.bidiag(num_matvecs, materialize=True)
-        (u, v), B, *_ = algorithm(Av, v0)
+        (u, v), B, *_ = bidiag(Av, v0)
 
         # Compute SVD of factorisation
         U, S, Vt = linalg.svd(B, full_matrices=False)

--- a/tests/test_eig/test_svd_partial.py
+++ b/tests/test_eig/test_svd_partial.py
@@ -1,6 +1,6 @@
 """Tests for SVD functionality."""
 
-from matfree import eig, test_util
+from matfree import decomp, eig, test_util
 from matfree.backend import linalg, np, testing
 
 
@@ -32,7 +32,8 @@ def test_equal_to_linalg_svd(A):
     v0 = np.ones((ncols,))
     v0 /= linalg.vector_norm(v0)
 
-    svd = eig.svd_partial(num_matvecs)
+    bidiag = decomp.bidiag(num_matvecs)
+    svd = eig.svd_partial(bidiag)
     U, S, Vt = svd(Av, v0)
 
     U_, S_, Vt_ = linalg.svd(A, full_matrices=False)


### PR DESCRIPTION
Resolves #223.


- From now on, `matfree.eig.svd_partial` returns a function that implements the partial SVD. This allows calling jit, grad, vmap, etc. on the function without having to resort to things like functools.partial. See #223.
- To mirror the signature of matfree.funm.*, the partial svd does not assume a number of matvecs but now expects an implementation of bidiagonalisation. Currently, there is only one type. But in the future, this will allow controlling the type of bidiagonalisation (eg reorthogonalisation, custom vjps, etc.). 

This change is not backwards compatible. 