### PR TITLE
Rename 'use_custom_vjp' to 'custom_vjp' to ensure consistency with the rest of the code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-merge-conflict
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.11
+    rev: v0.12.4
     hooks:
       # Run the linter.
       - id: ruff
@@ -19,7 +19,7 @@ repos:
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.17.0
     hooks:
       - id: mypy
         args:

--- a/matfree/lstsq.py
+++ b/matfree/lstsq.py
@@ -21,9 +21,9 @@ def lsmr(
     btol: float = 1e-6,
     ctol: float = 1e-8,
     maxiter: int = 1_000_000,
-    while_loop=control_flow.while_loop,
-    use_custom_vjp=True,
-    damp=0.0,
+    while_loop: Callable = control_flow.while_loop,
+    custom_vjp: bool = True,
+    damp: float = 0.0,
 ):
     """Construct an experimental implementation of LSMR.
 
@@ -337,7 +337,7 @@ def lsmr(
             "istop": state.istop,
         }
 
-    if use_custom_vjp:
+    if custom_vjp:
         return _lstsq_custom_vjp(run)
     return run
 


### PR DESCRIPTION
Decompositions like `hessenberg()` have a `custom_vjp` argument, but `lsmr()` had a `use_custom_vjp` argument. This PR changes this to ensure consistency between functions.
