### PR TITLE
Raise a ValueError in the Hessenberg-adjoints if num_matvecs=0 to catch an existing error

### DIFF
--- a/matfree/decomp.py
+++ b/matfree/decomp.py
@@ -463,6 +463,7 @@ def _hessenberg_adjoint(matvec, *params, Q, H, r, c, dQ, dH, dr, dc, reortho: st
     _, num_matvecs = np.shape(Q)
     if num_matvecs == 0:
         msg = "Custom Hessenberg-adjoints are not implemented for num_matvecs = 0."
+        # todo: implement this corner case
         raise ValueError(msg)
 
     # Prepare a bunch of auxiliary matrices

--- a/matfree/decomp.py
+++ b/matfree/decomp.py
@@ -461,6 +461,9 @@ def _hessenberg_forward_step(Q, H, v, length, matvec, *params, idx, reortho: str
 def _hessenberg_adjoint(matvec, *params, Q, H, r, c, dQ, dH, dr, dc, reortho: str):
     # Extract the matrix shapes from Q
     _, num_matvecs = np.shape(Q)
+    if num_matvecs == 0:
+        msg = "Custom Hessenberg-adjoints are not implemented for num_matvecs = 0."
+        raise ValueError(msg)
 
     # Prepare a bunch of auxiliary matrices
 

--- a/tests/test_decomp/test_hessenberg_adjoint.py
+++ b/tests/test_decomp/test_hessenberg_adjoint.py
@@ -36,7 +36,7 @@ def test_adjoint_matches_jax_dot_vjp(nrows, num_matvecs, reortho, dtype):
 
     # Assert that the values are only similar, not identical
     assert not np.all(dv_adjoint == dv_autodiff)
-    assert not np.all(dp_adjoint == dp_autodiff) @ testing.parametrize("nrows", [3])
+    assert not np.all(dp_adjoint == dp_autodiff)
 
 
 @testing.parametrize("nrows", [3])


### PR DESCRIPTION
Currently, the code doesn't work in this case anyway so it's better to have an informed error than an unexpected crash.