### PR TITLE
Allow initial guesses to be passed to LSMR

### DIFF
--- a/matfree/backend/testing.py
+++ b/matfree/backend/testing.py
@@ -24,5 +24,9 @@ def warns(warning, /):
     return pytest.warns(warning)
 
 
+def filterwarnings(warning, /):
+    return pytest.mark.filterwarnings(warning)
+
+
 def case():
     return pytest_cases.case()

--- a/tests/test_lstsq.py
+++ b/tests/test_lstsq.py
@@ -1,7 +1,7 @@
 """Tests for least-squares functionality."""
 
 from matfree import lstsq, test_util
-from matfree.backend import func, linalg, np, prng, testing
+from matfree.backend import config, func, linalg, np, prng, testing
 
 
 def case_A_shape_wide() -> tuple:
@@ -66,6 +66,9 @@ def test_output_matches_original_scipy_lsmr(A_shape: tuple):
     import numpy as onp  # noqa: ICN001
     import scipy.sparse.linalg
 
+    # Scipy uses double precision, so we emulate this behaviour
+    config.update("jax_enable_x64", True)
+
     key = prng.prng_key(1)
     key, subkey = prng.split(key, 2)
     matrix = prng.normal(subkey, shape=A_shape)
@@ -90,3 +93,6 @@ def test_output_matches_original_scipy_lsmr(A_shape: tuple):
     )
 
     assert np.allclose(sol, np.asarray(sol2))
+
+    # Scipy uses double precision, so we emulate this behaviour
+    config.update("jax_enable_x64", False)

--- a/tests/test_lstsq.py
+++ b/tests/test_lstsq.py
@@ -50,5 +50,8 @@ def test_value_and_grad_matches_numpy_lstsq(A_shape: tuple, provide_x0: bool):
     drhs2, [dmatrix2] = received_vjp(dsol)  # mind the order of rhs & matrix
 
     test_util.assert_allclose(received, expected)
-    test_util.assert_allclose(dmatrix1, dmatrix2)
+
+    print(dmatrix1)
+    print(dmatrix2)
     test_util.assert_allclose(drhs1, drhs2)
+    test_util.assert_allclose(dmatrix1, dmatrix2)

--- a/tests/test_lstsq.py
+++ b/tests/test_lstsq.py
@@ -32,9 +32,8 @@ def test_value_and_grad_matches_numpy_lstsq(A_shape: tuple, provide_x0: bool):
     # so the comparison to np.linalg.lstsq() is no longer valid. Thus, the caveat below.
     key, subkey = prng.split(key, num=2)
     is_wide = A_shape[1] > A_shape[0]
-    x0 = (
-        prng.normal(subkey, shape=(A_shape[1],)) if provide_x0 and not is_wide else None
-    )
+    x0_suggestion = prng.normal(subkey, shape=(A_shape[1],))
+    x0 = x0_suggestion if provide_x0 and not is_wide else None
 
     def lstsq_jnp(a, b):
         sol, *_ = linalg.lstsq(a, b)
@@ -55,8 +54,6 @@ def test_value_and_grad_matches_numpy_lstsq(A_shape: tuple, provide_x0: bool):
     received, received_vjp = func.vjp(lstsq_matfree, rhs, [matrix])
     drhs2, [dmatrix2] = received_vjp(dsol)  # mind the order of rhs & matrix
 
-    print(received)
-    print(expected)
     test_util.assert_allclose(received, expected)
     test_util.assert_allclose(drhs1, drhs2)
     test_util.assert_allclose(dmatrix1, dmatrix2)
@@ -92,4 +89,4 @@ def test_output_matches_original_scipy_lsmr(A_shape: tuple):
         matrix, rhs, atol=1e-5, btol=1e-5, conlim=1e5, damp=damp, x0=x0
     )
 
-    assert np.allclose(sol, sol2)
+    assert np.allclose(sol, np.asarray(sol2))


### PR DESCRIPTION
This is a breaking change, because `damp` and `x0` are now arguments to the lsmr function. Previously, `damp` was passed to the constructor and `x0` wasn't passed at all. Everything else is the same so I expected that almost every user will not notice any difference.