### PR TITLE
feat(stochtrace): Add sampler for the unit sphere

### DIFF
--- a/matfree/backend/np.py
+++ b/matfree/backend/np.py
@@ -34,8 +34,8 @@ def asarray(obj, /):
     return jnp.asarray(obj)
 
 
-def eye(n_rows):
-    return jnp.eye(n_rows)
+def eye(n_rows, /, dtype=None):
+    return jnp.eye(n_rows, dtype=dtype)
 
 
 def ones_like(x, /):

--- a/matfree/backend/np.py
+++ b/matfree/backend/np.py
@@ -127,6 +127,10 @@ def std(x, /, axis=None):
     return jnp.std(x, axis)
 
 
+def cov(x, /, rowvar=True, ddof=None):
+    return jnp.cov(x, rowvar=rowvar, ddof=ddof)
+
+
 def sum(x, /, axis=None):  # noqa: A001
     return jnp.sum(x, axis)
 

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -14,10 +14,7 @@ def estimator(integrand: Callable, /, sampler: Callable) -> Callable:
         [integrand_trace][matfree.stochtrace.integrand_trace].
         But any other integrand works, too.
     sampler
-        The sample function. Usually, either
-        [sampler_normal][matfree.stochtrace.sampler_normal],
-        [sampler_rademacher][matfree.stochtrace.sampler_rademacher],
-        or [sampler_sphere][matfree.stochtrace.sampler_sphere].
+        The sample function. See below for recommendations.
 
     Returns
     -------
@@ -26,8 +23,19 @@ def estimator(integrand: Callable, /, sampler: Callable) -> Callable:
         This function can be compiled, vectorised, differentiated,
         or looped over as the user desires.
 
-    """
+    Notes
+    -----
+    The statistical efficiency of the estimator for a given sampler depends on properties
+    of the operator, but we can provide some general advice. For an `n`-dimensional operator (see references):
+    - If the operator is real-valued and `n > O(100)`, use [sampler_rademacher][matfree.stochtrace.sampler_rademacher].
+    - If the operator is real-valued and `n < O(100)`, use [sampler_rademacher][matfree.stochtrace.sampler_rademacher] if the operator is known to be diagonal-dominant or [sampler_sphere][matfree.stochtrace.sampler_sphere] otherwise.
+    - If the operator is complex-valued, use [sampler_sphere][matfree.stochtrace.sampler_sphere] with a complex dtype.
 
+    References
+    ----------
+    - Epperly, E. (2023). [Stochastic trace estimation](https://www.ethanepperly.com/index.php/2023/01/26/stochastic-trace-estimation/).
+    - Epperly, E. (2024). [Don't use Gaussians in stochastic trace estimation](https://www.ethanepperly.com/index.php/2024/01/28/dont-use-gaussians-in-stochastic-trace-estimation/).
+    """
     def estimate(matvecs, key, *parameters):
         samples = sampler(key)
         Qs = func.vmap(lambda vec: integrand(matvecs, vec, *parameters))(samples)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -137,6 +137,11 @@ def sampler_rademacher(*args_like, num):
     return _sampler_from_jax_random(prng.rademacher, *args_like, num=num)
 
 
+def sampler_sphere(*args_like, num):
+    """Construct a function that samples from a unit sphere scaled to have identity covariance."""
+    return _sampler_from_jax_random(_random_sphere, *args_like, num=num)
+
+
 def _sampler_from_jax_random(sampler, *args_like, num):
     x_flat, unflatten = tree.ravel_pytree(*args_like)
 
@@ -145,3 +150,10 @@ def _sampler_from_jax_random(sampler, *args_like, num):
         return func.vmap(unflatten)(samples)
 
     return sample
+
+
+# sampler from the scaled sphere with the API of samplers in jax.random
+def _random_sphere(key, shape=(), dtype=None):
+    x = prng.normal(key, shape=shape, dtype=dtype)
+    sqrtn = np.sqrt(x.shape[-1])
+    return func.vmap(lambda v: v * (sqrtn / linalg.vector_norm(v)))(x)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -140,7 +140,17 @@ def sampler_rademacher(*args_like, num):
 
 def sampler_sphere(*args_like, num):
     """Construct a function that samples from a unit sphere scaled to have identity covariance."""
-    return _sampler_from_jax_random(_random_sphere, *args_like, num=num)
+    x_flat, unflatten = tree.ravel_pytree(*args_like)
+    n = x_flat.shape[0]
+    sqrtn = np.sqrt(n)
+
+    def sample(key):
+        samples = prng.normal(key, shape=(num, n), dtype=x_flat.dtype)
+        return func.vmap(lambda x: unflatten(x * (sqrtn / linalg.vector_norm(x))))(
+            samples
+        )
+
+    return sample
 
 
 def _sampler_from_jax_random(sampler, *args_like, num):
@@ -151,10 +161,3 @@ def _sampler_from_jax_random(sampler, *args_like, num):
         return func.vmap(unflatten)(samples)
 
     return sample
-
-
-def _random_sphere(key, shape=(), dtype=None):
-    """Sample from a scaled sphere with the API of the samplers in jax.random."""
-    x = prng.normal(key, shape=shape, dtype=dtype)
-    sqrtn = np.sqrt(x.shape[-1])
-    return func.vmap(lambda v: v * (sqrtn / linalg.vector_norm(v)))(x)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -36,6 +36,7 @@ def estimator(integrand: Callable, /, sampler: Callable) -> Callable:
     - Epperly, E. (2023). [Stochastic trace estimation](https://www.ethanepperly.com/index.php/2023/01/26/stochastic-trace-estimation/).
     - Epperly, E. (2024). [Don't use Gaussians in stochastic trace estimation](https://www.ethanepperly.com/index.php/2024/01/28/dont-use-gaussians-in-stochastic-trace-estimation/).
     """
+
     def estimate(matvecs, key, *parameters):
         samples = sampler(key)
         Qs = func.vmap(lambda vec: integrand(matvecs, vec, *parameters))(samples)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -141,11 +141,13 @@ def sampler_rademacher(*args_like, num):
 def sampler_sphere(*args_like, num):
     """Construct a function that samples from a unit sphere scaled to have identity covariance."""
     x_flat, unflatten = tree.ravel_pytree(*args_like)
+    dtype = x_flat.dtype
+    rdtype = dtype.type(0).real.dtype
     n = x_flat.shape[0]
-    sqrtn = np.sqrt(n)
+    sqrtn = np.sqrt(n).astype(rdtype)
 
     def sample(key):
-        samples = prng.normal(key, shape=(num, n), dtype=x_flat.dtype)
+        samples = prng.normal(key, shape=(num, n), dtype=dtype)
         return func.vmap(lambda x: unflatten(x * (sqrtn / linalg.vector_norm(x))))(
             samples
         )

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -153,8 +153,8 @@ def _sampler_from_jax_random(sampler, *args_like, num):
     return sample
 
 
-# sampler from the scaled sphere with the API of samplers in jax.random
 def _random_sphere(key, shape=(), dtype=None):
+    """Sample from a scaled sphere with the API of the samplers in jax.random."""
     x = prng.normal(key, shape=shape, dtype=dtype)
     sqrtn = np.sqrt(x.shape[-1])
     return func.vmap(lambda v: v * (sqrtn / linalg.vector_norm(v)))(x)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -15,8 +15,9 @@ def estimator(integrand: Callable, /, sampler: Callable) -> Callable:
         But any other integrand works, too.
     sampler
         The sample function. Usually, either
-        [sampler_normal][matfree.stochtrace.sampler_normal] or
-        [sampler_rademacher][matfree.stochtrace.sampler_rademacher].
+        [sampler_normal][matfree.stochtrace.sampler_normal],
+        [sampler_rademacher][matfree.stochtrace.sampler_rademacher],
+        or [sampler_sphere][matfree.stochtrace.sampler_sphere].
 
     Returns
     -------

--- a/tests/test_stochtrace/test_samplers.py
+++ b/tests/test_stochtrace/test_samplers.py
@@ -18,7 +18,7 @@ def test_sampler_sphere(n, dtype):
         assert not np.allclose(x.imag, 0)
     # Verify moments
     assert np.allclose(np.mean(x, axis=0), 0, atol=1e-2)
-    assert np.allclose(np.cov(x, axis=0), np.eye(n, dtype=dtype), atol=1e-2)
+    assert np.allclose(np.cov(x, rowvar=False, ddof=0), np.eye(n, dtype=dtype), atol=1e-2)
     
     # Verify determinism (same key)
     x_again = sampler(key1)

--- a/tests/test_stochtrace/test_samplers.py
+++ b/tests/test_stochtrace/test_samplers.py
@@ -18,16 +18,17 @@ def test_sampler_sphere(n, dtype):
         assert not np.allclose(x.imag, 0)
     # Verify moments
     assert np.allclose(np.mean(x, axis=0), 0, atol=1e-2)
-    assert np.allclose(np.cov(x, rowvar=False, ddof=0), np.eye(n, dtype=dtype), atol=1e-2)
-    
+    assert np.allclose(
+        np.cov(x, rowvar=False, ddof=0), np.eye(n, dtype=dtype), atol=1e-2
+    )
+
     # Verify determinism (same key)
     x_again = sampler(key1)
     assert np.allclose(x, x_again)
-    
+
     # Verify that samples differ if the key changes
     y = sampler(key2)
     assert not np.allclose(x, y)
-
 
 
 def test_sampler_sphere_pytrees():

--- a/tests/test_stochtrace/test_samplers.py
+++ b/tests/test_stochtrace/test_samplers.py
@@ -9,21 +9,25 @@ from matfree.backend import np, prng, testing
 def test_sampler_sphere(n, dtype):
     """Assert that the sampler_sphere samples from a unit sphere scaled to have identity covariance."""
 
-    num_samples = 100000
+    num_samples = 100_000
     key1, key2 = prng.split(prng.prng_key(1), 2)
     sampler = stochtrace.sampler_sphere(np.ones(n, dtype=dtype), num=num_samples)
     x = sampler(key1)
     if dtype is complex:
         # hack to check that the result is complex
         assert not np.allclose(x.imag, 0)
-    x2 = sampler(key1)
-    y = sampler(key2)
-    assert np.allclose(x, x2)
-    assert not np.allclose(x, y)
+    # Verify moments
     assert np.allclose(np.mean(x, axis=0), 0, atol=1e-2)
-    assert np.allclose(
-        (x.T.conj() @ x) / num_samples, np.eye(n).astype(dtype), atol=1e-2
-    )
+    assert np.allclose(np.cov(x, axis=0), np.eye(n, dtype=dtype), atol=1e-2)
+    
+    # Verify determinism (same key)
+    x_again = sampler(key1)
+    assert np.allclose(x, x_again)
+    
+    # Verify that samples differ if the key changes
+    y = sampler(key2)
+    assert not np.allclose(x, y)
+
 
 
 def test_sampler_sphere_pytrees():

--- a/tests/test_stochtrace/test_samplers.py
+++ b/tests/test_stochtrace/test_samplers.py
@@ -1,0 +1,38 @@
+"""Test samplers for stochastic trace estimation."""
+
+from matfree import stochtrace
+from matfree.backend import np, prng, testing
+
+
+@testing.parametrize("n", [5])
+@testing.parametrize("dtype", [float, complex])
+def test_sampler_sphere(n, dtype):
+    """Assert that the sampler_sphere samples from a unit sphere scaled to have identity covariance."""
+
+    num_samples = 100000
+    key1, key2 = prng.split(prng.prng_key(1), 2)
+    sampler = stochtrace.sampler_sphere(np.ones(n, dtype=dtype), num=num_samples)
+    x = sampler(key1)
+    if dtype is complex:
+        # hack to check that the result is complex
+        assert not np.allclose(x.imag, 0)
+    x2 = sampler(key1)
+    y = sampler(key2)
+    assert np.allclose(x, x2)
+    assert not np.allclose(x, y)
+    assert np.allclose(np.mean(x, axis=0), 0, atol=1e-2)
+    assert np.allclose(
+        (x.T.conj() @ x) / num_samples, np.eye(n).astype(dtype), atol=1e-2
+    )
+
+
+def test_sampler_sphere_pytrees():
+    """Assert that the sampler_sphere supports pytrees."""
+    n1, n2, num_samples = 3, 4, 5
+    x = {"a": np.ones(n1), "b": np.ones(n2)}
+    sampler = stochtrace.sampler_sphere(x, num=num_samples)
+    x = sampler(prng.prng_key(1))
+    assert type(x) is dict
+    assert set(x.keys()) == {"a", "b"}
+    assert x["a"].shape == (num_samples, n1)
+    assert x["b"].shape == (num_samples, n2)


### PR DESCRIPTION
This PR adds `sampler_sphere` for generating samples on the scaled sphere $$\sqrt{n} \mathbb{S}^{n-1} \subset \mathbb{R}^n$$.

As indicated by https://www.ethanepperly.com/index.php/2024/01/28/dont-use-gaussians-in-stochastic-trace-estimation/, the variance of Hutchinson's estimator when using the sphere sampler is always lower than that when using the normal sampler. Since the estimator is unbiased, that means `sampler_sphere` will always produce a more accurate estimate on average than `sampler_normal` for the same number of matvecs.