### PR TITLE
Make flaky tests more robust and test them with multiple seeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ format-and-lint:
 	pre-commit run --all-files
 
 test:
-	pytest
+	pytest -n auto
 	python -m doctest README.md
 	python -m doctest matfree/*.py
 	python tutorials/1_log_determinants.py

--- a/matfree/backend/np.py
+++ b/matfree/backend/np.py
@@ -181,7 +181,9 @@ def shape(x, /):
 
 
 def dtype(x, /):
-    return jnp.dtype(x.dtype if isinstance(x, jax.Array) else x)
+    if isinstance(x, jax.Array):
+        return jnp.dtype(x.dtype)
+    return jnp.dtype(x)
 
 
 # Functional implementation of constants

--- a/matfree/backend/np.py
+++ b/matfree/backend/np.py
@@ -181,7 +181,7 @@ def shape(x, /):
 
 
 def dtype(x, /):
-    return jnp.dtype(x)
+    return jnp.dtype(x.dtype if isinstance(x, jax.Array) else x)
 
 
 # Functional implementation of constants

--- a/matfree/test_util.py
+++ b/matfree/test_util.py
@@ -59,7 +59,7 @@ def assert_columns_orthonormal(Q, /):
     assert_allclose(eye_like, ref)
 
 
-def assert_allclose(a, b, /):
+def assert_allclose(a, b, /, atol=None, rtol=None):
     """Assert that two arrays are close.
 
     This function uses a different default tolerance to
@@ -68,9 +68,13 @@ def assert_allclose(a, b, /):
     """
     a = np.asarray(a)
     b = np.asarray(b)
+
     tol = 10 * np.sqrt(np.finfo_eps(np.dtype(a)))
 
     # For double precision sqrt(eps) is very tight...
     if tol < 1e-6:
         tol *= 10
-    assert np.allclose(a, b, atol=tol, rtol=tol)
+
+    rtol = rtol if rtol is not None else tol
+    atol = atol if atol is not None else tol
+    assert np.allclose(a, b, atol=atol, rtol=atol)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ cpu = [
 test =[
     "pytest",
     "pytest-cases",
+    "pytest-xdist",
 ]
 format-and-lint =[
     "matfree[test]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ convention = "numpy"
 
 
 [tool.pytest.ini_options]
-addopts = "-v"
+addopts = "-v -Werror"
 testpaths = [
     "tests"
 ]

--- a/tests/test_decomp/test_hessenberg_adjoint.py
+++ b/tests/test_decomp/test_hessenberg_adjoint.py
@@ -64,13 +64,15 @@ def test_custom_adjoint_k_zero_raises_valueerror(nrows, dtype):
 @testing.parametrize("nrows", [15])
 @testing.parametrize("num_matvecs", [10])
 @testing.parametrize("reortho", ["full"])
+@testing.parametrize("seed", [1, 2, 3])
 def test_adjoint_matches_jax_dot_vjp_hilbert_matrix_and_full_reortho(
-    nrows, num_matvecs, reortho
+    nrows, num_matvecs, reortho, seed
 ):
     config.update("jax_enable_x64", True)
+
     # Create a matrix and a direction as a test-case
     A = _lower(linalg.hilbert(nrows))
-    v = prng.normal(prng.prng_key(2), shape=(nrows,), dtype=A.dtype)
+    v = prng.normal(prng.prng_key(seed), shape=(nrows,), dtype=A.dtype)
 
     def matvec(s, p):
         return (p + p.T) @ s
@@ -88,15 +90,15 @@ def test_adjoint_matches_jax_dot_vjp_hilbert_matrix_and_full_reortho(
     _fwd_output, vjp_adjoint = func.vjp(algorithm_adjoint, v, A)
 
     # Random input gradients (no sparsity at all)
-    vjp_input = test_util.tree_random_like(prng.prng_key(3), fwd_output)
+    vjp_input = test_util.tree_random_like(prng.prng_key(seed + 1), fwd_output)
 
     # Call the auto-diff VJP
     dv_autodiff, dp_autodiff = vjp_autodiff(vjp_input)
     dv_adjoint, dp_adjoint = vjp_adjoint(vjp_input)
 
     # Assert gradients match
-    test_util.assert_allclose(dv_adjoint, dv_autodiff)
-    test_util.assert_allclose(dp_adjoint, dp_autodiff)
+    test_util.assert_allclose(dv_adjoint, dv_autodiff, atol=1e-3, rtol=1e-3)
+    test_util.assert_allclose(dp_adjoint, dp_autodiff, atol=1e-3, rtol=1e-3)
 
     # Assert that the values are only similar, not identical
     assert not np.all(dv_adjoint == dv_autodiff)

--- a/tests/test_decomp/test_tridiag_sym_adjoint.py
+++ b/tests/test_decomp/test_tridiag_sym_adjoint.py
@@ -7,10 +7,11 @@ from matfree.backend import func, linalg, np, prng, testing, tree
 @testing.parametrize("reortho", ["full", "none"])
 @testing.parametrize("n", [10])
 @testing.parametrize("krylov_num_matvecs", [4])
-def test_adjoint_vjp_matches_jax_vjp(reortho, n, krylov_num_matvecs):
+@testing.parametrize("seed", [1, 2, 3])
+def test_adjoint_vjp_matches_jax_vjp(reortho, n, krylov_num_matvecs, seed):
     """Test that the custom VJP yields the same output as autodiff."""
     # Set up a test-matrix
-    eigvals = prng.uniform(prng.prng_key(2), shape=(n,)) + 1.0
+    eigvals = prng.uniform(prng.prng_key(seed), shape=(n,)) + 1.0
     matrix = test_util.symmetric_matrix_from_eigenvalues(eigvals)
     params = _sym(matrix)
 
@@ -37,14 +38,14 @@ def test_adjoint_vjp_matches_jax_vjp(reortho, n, krylov_num_matvecs):
     # Compute both VJPs
     fx_ref, vjp_ref = func.vjp(reference, flat)
     fx_imp, vjp_imp = func.vjp(implementation, flat)
+
     # Assert that the forward-passes are identical
-    assert np.allclose(fx_ref, fx_imp)
+    assert np.allclose(fx_ref, fx_imp, atol=1e-4, rtol=1e-4)
 
     # Assert that the VJPs into a bunch of random directions are identical
-    for seed in [4, 5, 6]:
-        key = prng.prng_key(seed)
-        dnu = prng.normal(key, shape=np.shape(reference(flat)))
-        assert np.allclose(*vjp_ref(dnu), *vjp_imp(dnu), atol=1e-4, rtol=1e-4)
+    key = prng.prng_key(seed + 1)
+    dnu = prng.normal(key, shape=np.shape(reference(flat)))
+    assert np.allclose(*vjp_ref(dnu), *vjp_imp(dnu), atol=1e-4, rtol=1e-4)
 
 
 def _sym(m):

--- a/tests/test_funm/test_integrand_funm_product_schatten_norm.py
+++ b/tests/test_funm/test_integrand_funm_product_schatten_norm.py
@@ -18,7 +18,10 @@ def make_A(nrows, ncols, num_significant_singular_vals):
 @testing.parametrize("num_significant_singular_vals", [30])
 @testing.parametrize("num_matvecs", [20])
 @testing.parametrize("power", [1, 2, 3])
-def test_schatten_norm(nrows, ncols, num_significant_singular_vals, num_matvecs, power):
+@testing.parametrize("seed", [1, 2, 3])
+def test_schatten_norm(
+    nrows, ncols, num_significant_singular_vals, num_matvecs, power, seed
+):
     """Assert that the Schatten norm is accurate."""
     A = make_A(nrows, ncols, num_significant_singular_vals)
     _, s, _ = linalg.svd(A, full_matrices=False)
@@ -26,13 +29,16 @@ def test_schatten_norm(nrows, ncols, num_significant_singular_vals, num_matvecs,
 
     _, ncols = np.shape(A)
     args_like = np.ones((ncols,), dtype=float)
-    sampler = stochtrace.sampler_rademacher(args_like, num=500)
+    sampler = stochtrace.sampler_rademacher(args_like, num=5_000)
     bidiag = decomp.bidiag(num_matvecs)
     integrand = funm.integrand_funm_product_schatten_norm(power, bidiag)
     estimate = stochtrace.estimator(integrand, sampler)
 
-    key = prng.prng_key(1)
+    key = prng.prng_key(seed)
     received = estimate(lambda v: A @ v, key)
 
-    print_if_assert_fails = ("error", np.abs(received - expected), "target:", expected)
+    # Should be < 1 (the closer to 1, the tighter the test)
+    print_if_assert_fails = np.abs(received - expected) / (
+        0.01 * (1 + np.abs(expected))
+    )
     assert np.allclose(received, expected, atol=0.01, rtol=0.01), print_if_assert_fails


### PR DESCRIPTION
With the most recent JAX versions, some tests fail, and here is the fix.

- The Hessenberg and tridiagonalisation adjoints tests had too tight tolerances (it only passed for some seeds). I relaxed the tolerances and checked for multiple seeds.
- Similarly, the schatten norm tests failed for some python versions only; I relaxed the tolerances and ensured the tests pass for different seeds.
- The dtype call changed a bit, I updated the backend to recover the old version (at least for now, so we have time to fix things)


I also set the tests up so that they fail on warnings. 