### PR TITLE
feat(stochtrace)!: Replace sampler_rademacher with sampler_signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Estimate the trace of the matrix:
 ```python
 >>> # Determine the shape of the base-samples
 >>> input_like = jnp.zeros((2,), dtype=float)
->>> sampler = stochtrace.sampler_rademacher(input_like, num=10_000)
+>>> sampler = stochtrace.sampler_signs(input_like, num=10_000)
 >>>
 >>> # Set Hutchinson's method up to compute the traces
 >>> # (instead of, e.g., diagonals)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -147,6 +147,14 @@ def sampler_rademacher(*args_like, num):
     return _sampler_from_jax_random(prng.rademacher, *args_like, num=num)
 
 
+def sampler_signs(*args_like, num):
+    """Construct a function that samples signs uniformly.
+
+    For real dtypes, this samples from a Rademacher distribution (uniformly over `{-1, 1}`). For complex dtypes, this samples from a Steinhaus distribution on the complex unit circle.
+    """
+    return _sampler_from_jax_random(_uniform_signs, *args_like, num=num)
+
+
 def sampler_sphere(*args_like, num):
     """Construct a function that samples from a unit sphere scaled to have identity covariance."""
     x_flat, unflatten = tree.ravel_pytree(*args_like)
@@ -172,3 +180,14 @@ def _sampler_from_jax_random(sampler, *args_like, num):
         return func.vmap(unflatten)(samples)
 
     return sample
+
+
+def _steinhaus(key, shape=(), dtype=None):
+    """Sample from a Steinhaus distribution on the complex unit circle."""
+    return np.sign(prng.normal(key, shape=shape, dtype=dtype))
+
+
+def _uniform_signs(key, shape=(), dtype=None):
+    if dtype is not None and np.dtype(dtype).kind == "c":
+        return _steinhaus(key, shape=shape, dtype=dtype)
+    return prng.rademacher(key, shape=shape, dtype=dtype)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -177,14 +177,14 @@ def _sampler_from_jax_random(sampler, *args_like, num):
     return sample
 
 
-def _steinhaus(key, shape=(), dtype=None):
+def _steinhaus(key, /, shape, dtype):
     """Sample from a Steinhaus distribution on the complex unit circle."""
     rdtype = np.dtype(dtype).type(0).real.dtype
     angle = prng.uniform(key, shape=shape, dtype=rdtype) * (2 * np.pi())
     return np.cos(angle) + 1j * np.sin(angle)
 
 
-def _uniform_signs(key, shape=(), dtype=None):
-    if dtype is not None and np.dtype(dtype).kind == "c":
+def _uniform_signs(key, /, shape, dtype):
+    if np.dtype(dtype).kind == "c":
         return _steinhaus(key, shape=shape, dtype=dtype)
     return prng.rademacher(key, shape=shape, dtype=dtype)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -142,11 +142,6 @@ def sampler_normal(*args_like, num):
     return _sampler_from_jax_random(prng.normal, *args_like, num=num)
 
 
-def sampler_rademacher(*args_like, num):
-    """Construct a function that samples from a Rademacher distribution."""
-    return _sampler_from_jax_random(prng.rademacher, *args_like, num=num)
-
-
 def sampler_signs(*args_like, num):
     """Construct a function that samples signs uniformly.
 

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -179,7 +179,9 @@ def _sampler_from_jax_random(sampler, *args_like, num):
 
 def _steinhaus(key, shape=(), dtype=None):
     """Sample from a Steinhaus distribution on the complex unit circle."""
-    return np.sign(prng.normal(key, shape=shape, dtype=dtype))
+    rdtype = np.dtype(dtype).type(0).real.dtype
+    angle = prng.uniform(key, shape=shape, dtype=rdtype) * (2 * np.pi())
+    return np.cos(angle) + 1j * np.sin(angle)
 
 
 def _uniform_signs(key, shape=(), dtype=None):

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -27,8 +27,8 @@ def estimator(integrand: Callable, /, sampler: Callable) -> Callable:
     -----
     The statistical efficiency of the estimator for a given sampler depends on properties
     of the operator, but we can provide some general advice. For an `n`-dimensional operator (see references):
-    - If the operator is real-valued and `n > O(100)`, use [sampler_rademacher][matfree.stochtrace.sampler_rademacher].
-    - If the operator is real-valued and `n < O(100)`, use [sampler_rademacher][matfree.stochtrace.sampler_rademacher] if the operator is known to be diagonal-dominant or [sampler_sphere][matfree.stochtrace.sampler_sphere] otherwise.
+    - If the operator is real-valued and `n > O(100)`, use [sampler_signs][matfree.stochtrace.sampler_signs].
+    - If the operator is real-valued and `n < O(100)`, use [sampler_signs][matfree.stochtrace.sampler_signs] if the operator is known to be diagonal-dominant or [sampler_sphere][matfree.stochtrace.sampler_sphere] otherwise.
     - If the operator is complex-valued, use [sampler_sphere][matfree.stochtrace.sampler_sphere] with a complex dtype.
 
     References

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -27,9 +27,9 @@ def estimator(integrand: Callable, /, sampler: Callable) -> Callable:
     -----
     The statistical efficiency of the estimator for a given sampler depends on properties
     of the operator, but we can provide some general advice. For an `n`-dimensional operator (see references):
-    - If the operator is real-valued and `n > O(100)`, use [sampler_signs][matfree.stochtrace.sampler_signs].
-    - If the operator is real-valued and `n < O(100)`, use [sampler_signs][matfree.stochtrace.sampler_signs] if the operator is known to be diagonal-dominant or [sampler_sphere][matfree.stochtrace.sampler_sphere] otherwise.
-    - If the operator is complex-valued, use [sampler_sphere][matfree.stochtrace.sampler_sphere] with a complex dtype.
+    - `n > O(100)`, use [sampler_signs][matfree.stochtrace.sampler_signs].
+    - `n < O(100)`, use [sampler_signs][matfree.stochtrace.sampler_signs] if the operator is known to be diagonal-dominant or [sampler_sphere][matfree.stochtrace.sampler_sphere] otherwise.
+    - If the operator is complex-valued, pass a complex dtype to the sampler to approximately double the efficiency.
 
     References
     ----------

--- a/tests/test_funm/test_integrand_funm_product_logdet.py
+++ b/tests/test_funm/test_integrand_funm_product_logdet.py
@@ -26,7 +26,7 @@ def test_logdet_product(nrows, ncols, num_significant_singular_vals, num_matvecs
         return {"fx": A @ x["fx"]}
 
     x_like = {"fx": np.ones((ncols,), dtype=float)}
-    fun = stochtrace.sampler_rademacher(x_like, num=400)
+    fun = stochtrace.sampler_signs(x_like, num=400)
 
     bidiag = decomp.bidiag(num_matvecs)
     problem = funm.integrand_funm_product_logdet(bidiag)

--- a/tests/test_funm/test_integrand_funm_product_schatten_norm.py
+++ b/tests/test_funm/test_integrand_funm_product_schatten_norm.py
@@ -29,7 +29,7 @@ def test_schatten_norm(
 
     _, ncols = np.shape(A)
     args_like = np.ones((ncols,), dtype=float)
-    sampler = stochtrace.sampler_rademacher(args_like, num=5_000)
+    sampler = stochtrace.sampler_signs(args_like, num=5_000)
     bidiag = decomp.bidiag(num_matvecs)
     integrand = funm.integrand_funm_product_schatten_norm(power, bidiag)
     estimate = stochtrace.estimator(integrand, sampler)

--- a/tests/test_stochtrace/test_frobeniusnorm_squared.py
+++ b/tests/test_stochtrace/test_frobeniusnorm_squared.py
@@ -27,7 +27,7 @@ def test_frobeniusnorm_squared(seed, dtype):
 
     # Estimate the matrix function
     problem = stochtrace.integrand_frobeniusnorm_squared()
-    sampler = stochtrace.sampler_rademacher(args_like, num=100_000)
+    sampler = stochtrace.sampler_signs(args_like, num=100_000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
     received = estimate(jvp, key)
 

--- a/tests/test_stochtrace/test_samplers.py
+++ b/tests/test_stochtrace/test_samplers.py
@@ -41,3 +41,37 @@ def test_sampler_sphere_pytrees():
     assert set(x.keys()) == {"a", "b"}
     assert x["a"].shape == (num_samples, n1)
     assert x["b"].shape == (num_samples, n2)
+
+
+@testing.parametrize("n", [5])
+@testing.parametrize("dtype", [float, complex])
+def test_sampler_signs(n, dtype):
+    """Assert that the sampler_signs samples from a Rademacher/Steinhaus distribution."""
+    num_samples = 100_000
+    key = prng.prng_key(1)
+    x_like = np.ones(n, dtype=dtype)
+    sampler = stochtrace.sampler_signs(x_like, num=num_samples)
+    x = sampler(key)
+
+    # Verify basic properties
+    assert np.allclose(np.abs(x), 1)
+    if dtype is complex:
+        assert x.dtype.kind == "c"
+        assert not np.allclose(x.imag, 0)
+    else:
+        assert x.dtype.kind != "c"
+        assert np.allclose(x.imag, 0)
+
+    # Verify moments
+    assert np.allclose(np.mean(x), 0, atol=1e-2)
+    assert np.allclose(
+        np.cov(x, rowvar=False, ddof=0), np.eye(n, dtype=dtype), atol=1e-2
+    )
+
+    # Verify determinism (same key)
+    x_again = sampler(key)
+    assert np.allclose(x, x_again)
+
+    # Verify that samples differ if the key changes
+    y = sampler(prng.prng_key(2))
+    assert not np.allclose(x, y)

--- a/tests/test_stochtrace/test_wrap_moments.py
+++ b/tests/test_stochtrace/test_wrap_moments.py
@@ -81,14 +81,14 @@ def test_yields_correct_variance_normal(J_and_jvp, key):
     assert np.allclose(second - first**2, norm * 2, rtol=0.3)
 
 
-def test_yields_correct_variance_rademacher(J_and_jvp, key):
+def test_yields_correct_variance_signs(J_and_jvp, key):
     """Assert that the estimated trace approximates the true trace accurately."""
     # Estimate the trace
     J, jvp, args_like = J_and_jvp
 
     problem = stochtrace.integrand_trace()
     problem = stochtrace.integrand_wrap_moments(problem, moments=[1, 2])
-    sampler = stochtrace.sampler_rademacher(args_like, num=5000)
+    sampler = stochtrace.sampler_signs(args_like, num=5000)
     estimate = stochtrace.estimator(problem, sampler=sampler)
     first, second = estimate(jvp, key)
 

--- a/tutorials/6_low_memory_trace_estimation.py
+++ b/tutorials/6_low_memory_trace_estimation.py
@@ -35,7 +35,7 @@ def large_matvec(v):
 
 integrand = stochtrace.integrand_trace()
 x0 = jnp.ones((nrows,))
-sampler = stochtrace.sampler_rademacher(x0, num=nsamples)
+sampler = stochtrace.sampler_signs(x0, num=nsamples)
 estimate = stochtrace.estimator(integrand, sampler)
 
 key = jax.random.PRNGKey(1)
@@ -48,7 +48,7 @@ print(trace)
 # Instead, we can loop around estimate() to do the following:
 # The below code requires nrows $\times$ 1 storage:
 
-sampler = stochtrace.sampler_rademacher(x0, num=1)
+sampler = stochtrace.sampler_signs(x0, num=1)
 estimate = stochtrace.estimator(integrand, sampler)
 estimate = functools.partial(estimate, large_matvec)
 


### PR DESCRIPTION
This is a proposed fix to #267 that adds a `sampler_signs` that is the same as the current `sampler_rademacher` for real dtypes and for complex dtypes samples from the Steinhaus distribution. This is breaking because it removes `sampler_rademacher`, but alternatively we could just deprecate `sampler_rademacher`.

Closes #267 