### PR TITLE
Fix maths rendering issue in documentation

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,15 +1,9 @@
-// Taken from:
-// https://squidfunk.github.io/mkdocs-material/reference/mathjax/#docsjavascriptsmathjaxjs
 window.MathJax = {
   tex: {
-    inlineMath: [["\\(", "\\)"]],
-    displayMath: [["\\[", "\\]"]],
+    inlineMath: [["\\(", "\\)"], ["$", "$"]],
+    displayMath: [["\\[", "\\]"], ["$$", "$$"]],
     processEscapes: true,
     processEnvironments: true
-  },
-  options: {
-    ignoreHtmlClass: ".*|",
-    processHtmlClass: "arithmatex"
   }
 };
 


### PR DESCRIPTION
Resolves #273.

After: 
<img width="811" height="341" alt="image" src="https://github.com/user-attachments/assets/97bc6875-334e-4173-b332-d4b45e6a7bfe" />
