### PR TITLE
Remove polyfill.js from extra_javascript

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,5 +65,4 @@ markdown_extensions:
 extra_javascript:
   # From: https://squidfunk.github.io/mkdocs-material/reference/mathjax/#mkdocsyml
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
The [website polyfill.io has been compromised](https://www.bleepingcomputer.com/news/security/polyfillio-javascript-supply-chain-attack-impacts-over-100k-sites/) and its JS delivery is injecting malicious code login popups into websites
<img width="1770" height="620" alt="image" src="https://github.com/user-attachments/assets/79cef946-a533-46ef-8332-2ff970a6ca9c" />

It should be fine to remove it since it just ensures backward compatibility on some JS features which most modern browsers support by now.
