### PR TITLE
feat(stochtrace): Add estimators of the squared row norm

### DIFF
--- a/matfree/backend/func.py
+++ b/matfree/backend/func.py
@@ -46,6 +46,18 @@ def linear_transpose(func, *primals):
     return jax.linear_transpose(func, *primals)
 
 
+def linear_adjoint(func, *primals):
+    transpose = jax.linear_transpose(func, *primals)
+
+    def tree_conj(x):
+        return jax.tree.map(lambda x: x.conj(), x)
+
+    def adjoint(*primal_results):
+        return tree_conj(transpose(*tree_conj(primal_results)))
+
+    return adjoint
+
+
 def grad(func):
     return jax.grad(func)
 

--- a/matfree/backend/typing.py
+++ b/matfree/backend/typing.py
@@ -6,6 +6,7 @@ from typing import (  # noqa: F401, UP035
     Any,
     Generic,
     Iterable,
+    NamedTuple,
     Sequence,
     Tuple,
     TypeVar,

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -530,17 +530,8 @@ def leave_one_out_xnysdiag(
     return integrand
 
 
-def leave_one_out_xrownorms_squared(*, is_normal: bool = False) -> Callable:
-    """Construct an integrand for estimating squared row norms using the XRowNorm/XSymRowNorm algorithms (Epperly, 2025).
-
-    Parameters
-    ----------
-    is_normal
-        `True` indicates that the operator is normal (or almost-Hermitian), which allows for the more sample-efficient XSymRowNorm construction.
-        `False` uses the more general XRowNorm construction.
-
-        An operator `matvec` is normal if it commutes with its adjoint (i.e. conjugate-transpose-conjugate) operation `matvec_adj`.
-        That is, applying `matvec` followed by `matvec_adj` is equivalent to applying `matvec_adj` followed by `matvec`, up to numerical precision.
+def leave_one_out_xrownorms_squared() -> Callable:
+    """Construct an integrand for estimating squared row norms using the XRowNorm algorithm (Epperly, 2025).
 
     Returns
     -------
@@ -555,12 +546,48 @@ def leave_one_out_xrownorms_squared(*, is_normal: bool = False) -> Callable:
     -----
     To estimate squared column norms instead, pass the adjoint (i.e. conjugate-transpose-conjugate) of the matvec.
 
+    For normal operators (those that commute with their adjoint),
+    [leave_one_out_xsymrownorms_squared][matfree.stochtrace.leave_one_out_xsymrownorms_squared],
+    requires fewer matvecs per sample but is typically less accurate per sample.
+
     References
     ----------
     - Epperly EN (2025). Make the most of what you have: Resource-efficient randomized algorithms for matrix computations. PhD Thesis.
         arXiv: [2512.15929](https://arxiv.org/abs/2512.15929)
     """
+    return _leave_one_out_rownorms_squared(iterate_subspace=True)
 
+
+def leave_one_out_xsymrownorms_squared() -> Callable:
+    """Construct an integrand for estimating squared row norms using the XSymRowNorm algorithm (Epperly, 2025).
+
+    Returns
+    -------
+    integrand
+        An integrand function compatible with
+        [estimator_leave_one_out][matfree.stochtrace.estimator_leave_one_out]
+        whose input has the signature ``(matvec, samples, *params)`` and whose output is a
+        pytree with each leaf having shape ``(num_samples, n_k)``, giving one squared-row-norm
+        estimate per leave-one-out sample.
+        The ``matvec`` must be a normal operator, i.e. it must commute with its adjoint
+        (conjugate-transpose-conjugate) up to numerical precision.
+
+    Notes
+    -----
+    To estimate squared column norms instead, pass the adjoint (i.e. conjugate-transpose-conjugate) of the matvec.
+
+    For general (non-normal) operators, use
+    [leave_one_out_xrownorms_squared][matfree.stochtrace.leave_one_out_xrownorms_squared].
+
+    References
+    ----------
+    - Epperly EN (2025). Make the most of what you have: Resource-efficient randomized algorithms for matrix computations. PhD Thesis.
+        arXiv: [2512.15929](https://arxiv.org/abs/2512.15929)
+    """
+    return _leave_one_out_rownorms_squared(iterate_subspace=False)
+
+
+def _leave_one_out_rownorms_squared(*, iterate_subspace: bool):
     def integrand(matvec, samples, *params):
         sample0 = tree.tree_map(lambda s: s[0], samples)
         _, unflatten = tree.ravel_pytree(sample0)
@@ -578,9 +605,13 @@ def leave_one_out_xrownorms_squared(*, is_normal: bool = False) -> Callable:
         def matvec_flat(v):
             return tree.ravel_pytree(matvec(unflatten(v), *params))[0]
 
-        num_matvecs = (2 if is_normal else 3) * num_samples
+        def matvec_flat_adjoint(v):
+            return tree.ravel_pytree(func.linear_adjoint(matvec_flat, v))[0]
 
-        if num_matvecs >= n:
+        matmat = func.vmap(matvec_flat, in_axes=-1, out_axes=-1)
+
+        num_matvecs_per_sample = 2 + int(iterate_subspace)
+        if num_matvecs_per_sample * num_samples >= n:
             # It's faster, more accurate, and allocates less memory to compute the row
             # norms exactly and deterministically on the materialized operator when
             # the number of matvecs exceeds the input dimension of the operator
@@ -592,14 +623,11 @@ def leave_one_out_xrownorms_squared(*, is_normal: bool = False) -> Callable:
             )
             return func.vmap(unflatten_out)(srn_all.T)
 
-        matmat = func.vmap(matvec_flat, in_axes=-1, out_axes=-1)
-        matvec_flat_adjoint = func.linear_adjoint(matvec_flat, Omega[:, 0])
-
         G = matmat(Omega)
-        if is_normal:
-            Y = G
+        if iterate_subspace:
+            Y = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(G)
         else:
-            (Y,) = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(G)
+            Y = G
         Q, R = linalg.qr_reduced(Y)
 
         Z = matmat(Q)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -544,11 +544,13 @@ def leave_one_out_xrownorms_squared() -> Callable:
 
     Notes
     -----
-    To estimate squared column norms instead, pass the adjoint (i.e. conjugate-transpose-conjugate) of the matvec.
+    To estimate squared column norms instead, pass the adjoint (i.e. conjugate-transpose-conjugate) of the matvec (
+    see [`func.linear_adjoint`][matfree.func.linear_adjoint]).
 
     For normal operators (those that commute with their adjoint),
     [leave_one_out_xsymrownorms_squared][matfree.stochtrace.leave_one_out_xsymrownorms_squared],
-    requires fewer matvecs per sample but is typically less accurate per sample.
+    performs only 2/3 of the matvecs per sample compared to this algorithm but is typically less
+    accurate per sample.
 
     References
     ----------
@@ -559,7 +561,7 @@ def leave_one_out_xrownorms_squared() -> Callable:
 
 
 def leave_one_out_xsymrownorms_squared() -> Callable:
-    """Construct an integrand for estimating squared row norms using the XSymRowNorm algorithm (Epperly, 2025).
+    """Construct an integrand for estimating squared row norms of a normal operator using the XSymRowNorm algorithm (Epperly, 2025).
 
     Returns
     -------
@@ -569,12 +571,13 @@ def leave_one_out_xsymrownorms_squared() -> Callable:
         whose input has the signature ``(matvec, samples, *params)`` and whose output is a
         pytree with each leaf having shape ``(num_samples, n_k)``, giving one squared-row-norm
         estimate per leave-one-out sample.
+        The input and output pytree structures are assumed to be identical.
         The ``matvec`` must be a normal operator, i.e. it must commute with its adjoint
         (conjugate-transpose-conjugate) up to numerical precision.
 
     Notes
     -----
-    To estimate squared column norms instead, pass the adjoint (i.e. conjugate-transpose-conjugate) of the matvec.
+    For normal operators, the row and column norms are equal, so this algorithm can also be used to estimate squared column norms.
 
     For general (non-normal) operators, use
     [leave_one_out_xrownorms_squared][matfree.stochtrace.leave_one_out_xrownorms_squared].

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -319,15 +319,11 @@ def leave_one_out_xdiag() -> Callable:
                 np.ones((num_samples, 1), dtype=diag_B.dtype) * diag_B
             )
 
-        matvec_flat_transpose = func.linear_transpose(matvec_flat, Omega[:, 0])
-
-        def matvec_flat_adjoint(v):
-            (result,) = matvec_flat_transpose(v.conj())
-            return result.conj()
+        matvec_flat_adjoint = func.linear_adjoint(matvec_flat, Omega[:, 0])
 
         Y = func.vmap(matvec_flat, in_axes=-1, out_axes=-1)(Omega)
         Q, R = linalg.qr_reduced(Y)
-        Z = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(Q)
+        (Z,) = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(Q)
 
         def _diag_exact():
             diag_B = func.vmap(linalg.vdot, in_axes=0)(Z, Q)
@@ -597,18 +593,13 @@ def leave_one_out_xrownorms_squared(*, is_normal: bool = False) -> Callable:
             return func.vmap(unflatten_out)(srn_all.T)
 
         matmat = func.vmap(matvec_flat, in_axes=-1, out_axes=-1)
-
-        matvec_flat_transpose = func.linear_transpose(matvec_flat, Omega[:, 0])
-
-        def matvec_flat_adjoint(v):
-            (result,) = matvec_flat_transpose(v.conj())
-            return result.conj()
+        matvec_flat_adjoint = func.linear_adjoint(matvec_flat, Omega[:, 0])
 
         G = matmat(Omega)
         if is_normal:
             Y = G
         else:
-            Y = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(G)
+            (Y,) = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(G)
         Q, R = linalg.qr_reduced(Y)
 
         Z = matmat(Q)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -18,6 +18,7 @@ def estimator_monte_carlo(integrand: Callable, /, sampler: Callable) -> Callable
         [monte_carlo_trace][matfree.stochtrace.monte_carlo_trace],
         [monte_carlo_diagonal][matfree.stochtrace.monte_carlo_diagonal],
         [monte_carlo_frobeniusnorm_squared][matfree.stochtrace.monte_carlo_frobeniusnorm_squared],
+        [monte_carlo_rownorms_squared][matfree.stochtrace.monte_carlo_rownorms_squared],
         or any of the ``monte_carlo_funm_*`` functions from [matfree.funm][matfree.funm].
     sampler
         The sample function. See below for recommendations.
@@ -742,6 +743,24 @@ def monte_carlo_trace_and_diagonal():
         trace_form = linalg.inner(v_flat.conj(), Qv_flat)
         diagonal_form = unflatten(v_flat.conj() * Qv_flat)
         return {"trace": trace_form, "diagonal": diagonal_form}
+
+    return integrand
+
+
+def monte_carlo_rownorms_squared():
+    """Construct the integrand for estimating the squared row norms.
+
+    Use with [estimator_monte_carlo][matfree.stochtrace.estimator_monte_carlo].
+
+    Notes
+    -----
+    To estimate squared column norms instead, pass the adjoint (i.e. conjugate-transpose-conjugate) of the matvec.
+    """
+
+    def integrand(matvec, v, *parameters):
+        Qv = matvec(v, *parameters)
+        Qv_flat, unflatten = tree.ravel_pytree(Qv)
+        return unflatten(linalg.abs2(Qv_flat))
 
     return integrand
 

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -605,10 +605,8 @@ def _leave_one_out_rownorms_squared(*, iterate_subspace: bool):
         def matvec_flat(v):
             return tree.ravel_pytree(matvec(unflatten(v), *params))[0]
 
-        def matvec_flat_adjoint(v):
-            return tree.ravel_pytree(func.linear_adjoint(matvec_flat, v))[0]
-
         matmat = func.vmap(matvec_flat, in_axes=-1, out_axes=-1)
+        matvec_flat_adjoint = func.linear_adjoint(matvec_flat, Omega[:, 0])
 
         num_matvecs_per_sample = 2 + int(iterate_subspace)
         if num_matvecs_per_sample * num_samples >= n:
@@ -625,7 +623,7 @@ def _leave_one_out_rownorms_squared(*, iterate_subspace: bool):
 
         G = matmat(Omega)
         if iterate_subspace:
-            Y = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(G)
+            (Y,) = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(G)
         else:
             Y = G
         Q, R = linalg.qr_reduced(Y)

--- a/matfree/stochtrace.py
+++ b/matfree/stochtrace.py
@@ -534,6 +534,116 @@ def leave_one_out_xnysdiag(
     return integrand
 
 
+def leave_one_out_xrownorms_squared(*, is_normal: bool = False) -> Callable:
+    """Construct an integrand for estimating squared row norms using the XRowNorm/XSymRowNorm algorithms (Epperly, 2025).
+
+    Parameters
+    ----------
+    is_normal
+        `True` indicates that the operator is normal (or almost-Hermitian), which allows for the more sample-efficient XSymRowNorm construction.
+        `False` uses the more general XRowNorm construction.
+
+        An operator `matvec` is normal if it commutes with its adjoint (i.e. conjugate-transpose-conjugate) operation `matvec_adj`.
+        That is, applying `matvec` followed by `matvec_adj` is equivalent to applying `matvec_adj` followed by `matvec`, up to numerical precision.
+
+    Returns
+    -------
+    integrand
+        An integrand function compatible with
+        [estimator_leave_one_out][matfree.stochtrace.estimator_leave_one_out]
+        whose input has the signature ``(matvec, samples, *params)`` and whose output is a
+        pytree with each leaf having shape ``(num_samples, n_k)``, giving one squared-row-norm
+        estimate per leave-one-out sample.
+
+    Notes
+    -----
+    To estimate squared column norms instead, pass the adjoint (i.e. conjugate-transpose-conjugate) of the matvec.
+
+    References
+    ----------
+    - Epperly EN (2025). Make the most of what you have: Resource-efficient randomized algorithms for matrix computations. PhD Thesis.
+        arXiv: [2512.15929](https://arxiv.org/abs/2512.15929)
+    """
+
+    def integrand(matvec, samples, *params):
+        sample0 = tree.tree_map(lambda s: s[0], samples)
+        _, unflatten = tree.ravel_pytree(sample0)
+
+        out_shape = func.eval_shape(matvec, sample0, *params)
+        out0 = tree.tree_map(lambda s: np.zeros(s.shape, dtype=s.dtype), out_shape)
+        _, unflatten_out = tree.ravel_pytree(out0)
+
+        Omega = func.vmap(lambda s: tree.ravel_pytree(s)[0])(samples).T
+        n, num_samples = Omega.shape
+
+        if num_samples > n:
+            raise ValueError(_error_num_samples(num_samples, maxval=n, minval=1))
+
+        def matvec_flat(v):
+            return tree.ravel_pytree(matvec(unflatten(v), *params))[0]
+
+        num_matvecs = (2 if is_normal else 3) * num_samples
+
+        if num_matvecs >= n:
+            # It's faster, more accurate, and allocates less memory to compute the row
+            # norms exactly and deterministically on the materialized operator when
+            # the number of matvecs exceeds the input dimension of the operator
+            B_mat = _materialize_operator(matvec_flat, Omega[:, 0])
+            rownorms_squared = _rownorms_squared(B_mat)
+            srn_all = (
+                np.ones(num_samples, dtype=rownorms_squared.dtype)
+                * rownorms_squared[:, None]
+            )
+            return func.vmap(unflatten_out)(srn_all.T)
+
+        matmat = func.vmap(matvec_flat, in_axes=-1, out_axes=-1)
+
+        matvec_flat_transpose = func.linear_transpose(matvec_flat, Omega[:, 0])
+
+        def matvec_flat_adjoint(v):
+            (result,) = matvec_flat_transpose(v.conj())
+            return result.conj()
+
+        G = matmat(Omega)
+        if is_normal:
+            Y = G
+        else:
+            Y = func.vmap(matvec_flat_adjoint, in_axes=-1, out_axes=-1)(G)
+        Q, R = linalg.qr_reduced(Y)
+
+        Z = matmat(Q)
+        srn_B_hat = _rownorms_squared(Z)
+
+        def _rownorms_squared_exact():
+            return np.ones(num_samples, dtype=srn_B_hat.dtype) * srn_B_hat[:, None]
+
+        def _rownorms_squared_estimate():
+            S = _qr_leave_one_out_factor(R)
+
+            W = Q.T.conj() @ Omega
+            W_vd_S = func.vmap(linalg.vdot, in_axes=1)(W, S)
+            # Omega projected onto the subspace spanned by Q_i, i.e. Q formed leaving out Omega[:, i]
+            X = W - S * W_vd_S.conj()
+
+            # srn(B_hat) leaving out one sample
+            srn_B_hat_loo = srn_B_hat[:, None] - linalg.abs2(Z @ S)
+            # Johnson-Lindenstrauss estimate of srn(B - B_hat_{-i}) using samples[i, :] as probes.
+            srn_residual_loo = linalg.abs2(G - Z @ X)
+            return srn_B_hat_loo + srn_residual_loo
+
+        is_Y_rank_deficient = (
+            np.sum(np.abs(linalg.diagonal(R)) > np.finfo_eps(R.dtype)) < num_samples
+        )
+
+        srn_loo = control_flow.cond(
+            is_Y_rank_deficient, _rownorms_squared_exact, _rownorms_squared_estimate
+        )
+
+        return func.vmap(unflatten_out)(srn_loo.T)
+
+    return integrand
+
+
 def _qr_leave_one_out_factor(R):
     r"""Compute the downdate factor for a QR decomposition leaving out a single column.
 
@@ -696,6 +806,11 @@ def nystrom_eigh(
 def _symmetrize(x):
     r"""Symmetrize a matrix by computing \((x + x^H) / 2\)."""
     return (x + x.T.conj()) / 2
+
+
+def _rownorms_squared(X):
+    """Compute the squared row norms of a matrix."""
+    return np.sum(linalg.abs2(X), axis=1)
 
 
 def monte_carlo_diagonal():

--- a/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
+++ b/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
@@ -1,8 +1,14 @@
-"""Tests for leave_one_out_xrownorms_squared."""
+"""Tests for leave_one_out_xrownorms_squared and leave_one_out_xsymrownorms_squared."""
 
 from matfree import stochtrace, test_util
 from matfree.backend import config, func, linalg, np, prng, testing
 from matfree.backend.typing import Array, Callable, NamedTuple
+
+
+def _make_integrand(is_normal):
+    if is_normal:
+        return stochtrace.leave_one_out_xsymrownorms_squared()
+    return stochtrace.leave_one_out_xrownorms_squared()
 
 
 @testing.parametrize("is_normal", [False, True])
@@ -15,7 +21,7 @@ def test_xrownorms_squared_error_num_samples_more_than_dimension(n, is_normal):
     def matvec(v, A):
         return A @ v
 
-    integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
+    integrand = _make_integrand(is_normal)
     sampler = stochtrace.sampler_signs(np.ones(n), num=n + 1)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     message = f"Number of samples num={n + 1} exceeds the acceptable range."
@@ -53,7 +59,7 @@ def cases_exact_num_samples_at_least_dimension(n, is_normal):
     params = (A1, A2)
     x_like = {"x": np.ones(n1), "y": np.ones(n2)}
     sampler = stochtrace.sampler_signs(x_like, num=num_samples)
-    integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
+    integrand = _make_integrand(is_normal)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     return matvec, params, estimate, expected
 
@@ -81,7 +87,7 @@ def cases_exact_num_samples_more_than_rank(n, rank, dtype, is_normal):
     params = (A,)
     x_like = {"x": np.ones(n, dtype=dtype)}
     sampler = stochtrace.sampler_signs(x_like, num=num_samples)
-    integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
+    integrand = _make_integrand(is_normal)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     return matvec, params, estimate, expected
 
@@ -95,6 +101,7 @@ def test_xrownorms_squared_exact(matvec, params, estimate, expected):
     received = estimate(matvec, key, *params)
     for leaf, expected_leaf in expected.items():
         test_util.assert_allclose(received[leaf], expected_leaf)
+
 
 class _ExperimentParams(NamedTuple):
     make_A: Callable[[int, Array, type], Array]
@@ -176,7 +183,7 @@ def test_xrownorms_squared_reproduce_experiments(
 
     x_like = {"x": np.ones(n, dtype=dtype)}
     sampler = stochtrace.sampler_signs(x_like, num=num_samples)
-    integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
+    integrand = _make_integrand(is_normal)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
 
     def matvec(v, A):

--- a/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
+++ b/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
@@ -1,0 +1,151 @@
+"""Tests for leave_one_out_xrownorms_squared."""
+
+from matfree import stochtrace, test_util
+from matfree.backend import func, linalg, np, prng, testing, config
+
+
+@testing.parametrize("is_normal", [False, True])
+@testing.parametrize("n", [10, 20])
+def test_xrownorms_squared_error_num_samples_more_than_dimension(n, is_normal):
+    """Assert that num_samples greater than the dimension raises a ValueError."""
+    key = prng.prng_key(1)
+    A = np.eye(n)
+
+    def matvec(v, A):
+        return A @ v
+
+    integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
+    sampler = stochtrace.sampler_normal(np.ones(n), num=n + 1)
+    estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
+    message = f"Number of samples num={n + 1} exceeds the acceptable range."
+    message = f"{message} Expected: 1 <= num <= {n}."
+    with testing.raises(ValueError, match=message):
+        estimate(matvec, key, A)
+
+
+@testing.parametrize("is_normal", [False, True])
+@testing.parametrize("n", [12, 30])
+def cases_exact_num_samples_at_least_dimension(n, is_normal):
+    """Exact squared row norms when num_samples is at least n/2 (normal) or n/3 (general).
+
+    Uses two differently-sized pytree blocks, also exercising heterogeneous
+    pytree support.
+    """
+    n1 = max(1, n // 3)
+    n2 = n - n1
+    num_samples = n // 2 if is_normal else n // 3
+    key_eigvals1, key_eigvals2, key_eigvecs1, key_eigvecs2 = prng.split(
+        prng.prng_key(1), 4
+    )
+    eigvals1 = linalg.abs2(prng.normal(key_eigvals1, shape=(n1,)))
+    eigvals2 = linalg.abs2(prng.normal(key_eigvals2, shape=(n2,)))
+    A1 = test_util.hermitian_matrix_from_eigenvalues(eigvals1, key_eigvecs1)
+    A2 = test_util.hermitian_matrix_from_eigenvalues(eigvals2, key_eigvecs2)
+    expected = {
+        "fx": np.sum(linalg.abs2(A1), axis=1),
+        "fy": np.sum(linalg.abs2(A2), axis=1),
+    }
+
+    def matvec(v, A1, A2):
+        return {"fx": A1 @ v["x"], "fy": A2 @ v["y"]}
+
+    params = (A1, A2)
+    x_like = {"x": np.ones(n1), "y": np.ones(n2)}
+    sampler = stochtrace.sampler_normal(x_like, num=num_samples)
+    integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
+    estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
+    return matvec, params, estimate, expected
+
+
+@testing.parametrize("is_normal", [False, True])
+@testing.parametrize("dtype", [float, complex])
+@testing.parametrize("n, rank", [(50, 10), (100, 30)])
+def cases_exact_num_samples_more_than_rank(n, rank, dtype, is_normal):
+    """Exact squared row norms when num_samples exceeds the operator's rank."""
+    num_samples = rank + 1
+    key_mat1, key_mat2 = prng.split(prng.prng_key(1), 2)
+    if is_normal:
+        nz_eigvals = prng.normal(key_mat1, shape=(rank,), dtype=dtype)
+        eigvals = np.concatenate([nz_eigvals, np.zeros(n - rank, dtype=dtype)])
+        A = test_util.hermitian_matrix_from_eigenvalues(eigvals, key_mat2, dtype=dtype)
+    else:
+        A1 = prng.normal(key_mat1, shape=(n + 1, rank), dtype=dtype)
+        A2 = prng.normal(key_mat2, shape=(rank, n), dtype=dtype)
+        A = A1 @ A2
+    expected = {"fx": np.sum(linalg.abs2(A), axis=1)}
+
+    def matvec(v, A):
+        return {"fx": A @ v["x"]}
+
+    params = (A,)
+    x_like = {"x": np.ones(n, dtype=dtype)}
+    sampler = stochtrace.sampler_normal(x_like, num=num_samples)
+    integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
+    estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
+    return matvec, params, estimate, expected
+
+
+@testing.parametrize_with_cases(
+    "matvec, params, estimate, expected", cases=".", prefix="cases_exact_"
+)
+def test_xrownorms_squared_exact(matvec, params, estimate, expected):
+    """Assert exact squared row norms when num_samples is large enough."""
+    key = prng.prng_key(1)
+    received = estimate(matvec, key, *params)
+    for leaf, expected_leaf in expected.items():
+        test_util.assert_allclose(received[leaf], expected_leaf)
+
+
+def cases_experiments_exp_normal():
+    """Hermitian matrix with eigenvalues that decay rapidly, XSymRowNorm"""
+    return test_util.hermitian_matrix_eigvals_decaying, 50, 1e-12, True
+
+
+def cases_experiments_exp_general():
+    """Hermitian matrix with eigenvalues that decay rapidly, XRowNorm"""
+    return test_util.hermitian_matrix_eigvals_decaying, 35, 1e-9, False
+
+
+def cases_experiments_step_normal():
+    """Hermitian matrix with eigenvalues that are flat with a sudden drop, XSymRowNorm"""
+    return test_util.hermitian_matrix_eigvals_step, 60, 9e-3, True
+
+
+def cases_experiments_step_general():
+    """Hermitian matrix with eigenvalues that are flat with a sudden drop, XRowNorm"""
+    return test_util.hermitian_matrix_eigvals_step, 60, 5e-5, False
+
+
+@testing.parametrize("dtype", [float, complex])
+@testing.parametrize_with_cases(
+    "make_A, num_samples, max_rel_err, is_normal", cases=".", prefix="cases_experiments_"
+)
+def test_xrownorms_squared_reproduce_experiments(
+    make_A, num_samples, max_rel_err, is_normal, dtype
+):
+    """Assert that squared row norms are estimated accurately for structured spectra."""
+    requires_x64 = make_A is test_util.hermitian_matrix_eigvals_decaying
+    if requires_x64:
+        config.update("jax_enable_x64", True)
+    n = 1_000
+    num_rep = 10
+    key = prng.prng_key(50)
+    key_eigvecs, key = prng.split(key)
+    A = make_A(n, key_eigvecs, dtype=dtype)
+    expected = np.sum(linalg.abs2(A), axis=1)
+
+    x_like = {"x": np.ones(n, dtype=dtype)}
+    sampler = stochtrace.sampler_normal(x_like, num=num_samples)
+    integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
+    estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
+
+    def matvec(v, A):
+        return {"fx": A @ v["x"]}
+
+    key_ests = prng.split(key, num_rep)
+    received = func.vmap(lambda key: estimate(matvec, key, A))(key_ests)["fx"]
+    max_rel_errs = np.array_max(np.abs(received - expected) / np.abs(expected), axis=1)
+    median_max_rel_err = np.median(max_rel_errs)
+    assert float(median_max_rel_err) < max_rel_err
+    if requires_x64:
+        config.update("jax_enable_x64", False)

--- a/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
+++ b/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
@@ -1,7 +1,7 @@
 """Tests for leave_one_out_xrownorms_squared."""
 
 from matfree import stochtrace, test_util
-from matfree.backend import func, linalg, np, prng, testing, config
+from matfree.backend import config, func, linalg, np, prng, testing
 
 
 @testing.parametrize("is_normal", [False, True])
@@ -15,7 +15,7 @@ def test_xrownorms_squared_error_num_samples_more_than_dimension(n, is_normal):
         return A @ v
 
     integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
-    sampler = stochtrace.sampler_normal(np.ones(n), num=n + 1)
+    sampler = stochtrace.sampler_signs(np.ones(n), num=n + 1)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     message = f"Number of samples num={n + 1} exceeds the acceptable range."
     message = f"{message} Expected: 1 <= num <= {n}."
@@ -51,7 +51,7 @@ def cases_exact_num_samples_at_least_dimension(n, is_normal):
 
     params = (A1, A2)
     x_like = {"x": np.ones(n1), "y": np.ones(n2)}
-    sampler = stochtrace.sampler_normal(x_like, num=num_samples)
+    sampler = stochtrace.sampler_signs(x_like, num=num_samples)
     integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     return matvec, params, estimate, expected
@@ -79,7 +79,7 @@ def cases_exact_num_samples_more_than_rank(n, rank, dtype, is_normal):
 
     params = (A,)
     x_like = {"x": np.ones(n, dtype=dtype)}
-    sampler = stochtrace.sampler_normal(x_like, num=num_samples)
+    sampler = stochtrace.sampler_signs(x_like, num=num_samples)
     integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     return matvec, params, estimate, expected
@@ -113,12 +113,14 @@ def cases_experiments_step_normal():
 
 def cases_experiments_step_general():
     """Hermitian matrix with eigenvalues that are flat with a sudden drop, XRowNorm"""
-    return test_util.hermitian_matrix_eigvals_step, 60, 5e-5, False
+    return test_util.hermitian_matrix_eigvals_step, 60, 1e-5, False
 
 
 @testing.parametrize("dtype", [float, complex])
 @testing.parametrize_with_cases(
-    "make_A, num_samples, max_rel_err, is_normal", cases=".", prefix="cases_experiments_"
+    "make_A, num_samples, max_rel_err, is_normal",
+    cases=".",
+    prefix="cases_experiments_",
 )
 def test_xrownorms_squared_reproduce_experiments(
     make_A, num_samples, max_rel_err, is_normal, dtype
@@ -135,7 +137,7 @@ def test_xrownorms_squared_reproduce_experiments(
     expected = np.sum(linalg.abs2(A), axis=1)
 
     x_like = {"x": np.ones(n, dtype=dtype)}
-    sampler = stochtrace.sampler_normal(x_like, num=num_samples)
+    sampler = stochtrace.sampler_signs(x_like, num=num_samples)
     integrand = stochtrace.leave_one_out_xrownorms_squared(is_normal=is_normal)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
 

--- a/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
+++ b/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
@@ -2,6 +2,7 @@
 
 from matfree import stochtrace, test_util
 from matfree.backend import config, func, linalg, np, prng, testing
+from matfree.backend.typing import Array, Callable, NamedTuple
 
 
 @testing.parametrize("is_normal", [False, True])
@@ -95,40 +96,73 @@ def test_xrownorms_squared_exact(matvec, params, estimate, expected):
     for leaf, expected_leaf in expected.items():
         test_util.assert_allclose(received[leaf], expected_leaf)
 
+class _ExperimentParams(NamedTuple):
+    make_A: Callable[[int, Array, type], Array]
+    num_samples: int
+    max_rel_err: float
+    is_normal: bool
+    requires_x64: bool
+    dtype: type
 
 def cases_experiments_exp_normal():
     """Hermitian matrix with eigenvalues that decay rapidly, XSymRowNorm"""
-    return test_util.hermitian_matrix_eigvals_decaying, 50, 1e-12, True
+    return _ExperimentParams(
+        make_A=test_util.hermitian_matrix_eigvals_decaying,
+        num_samples=50,
+        max_rel_err=1e-12,
+        is_normal=True,
+        requires_x64=True,
+        dtype=dtype,
+    )
 
 
 def cases_experiments_exp_general():
     """Hermitian matrix with eigenvalues that decay rapidly, XRowNorm"""
-    return test_util.hermitian_matrix_eigvals_decaying, 35, 1e-9, False
+    return _ExperimentParams(
+        make_A=test_util.hermitian_matrix_eigvals_decaying,
+        num_samples=35,
+        max_rel_err=1e-9,
+        is_normal=False,
+        requires_x64=True,
+        dtype=dtype,
+    )
 
 
 def cases_experiments_step_normal():
     """Hermitian matrix with eigenvalues that are flat with a sudden drop, XSymRowNorm"""
-    return test_util.hermitian_matrix_eigvals_step, 60, 9e-3, True
+    return _ExperimentParams(
+        make_A=test_util.hermitian_matrix_eigvals_step,
+        num_samples=60,
+        max_rel_err=9e-3,
+        is_normal=True,
+        requires_x64=False,
+        dtype=dtype,
+    )
 
 
 def cases_experiments_step_general():
     """Hermitian matrix with eigenvalues that are flat with a sudden drop, XRowNorm"""
-    return test_util.hermitian_matrix_eigvals_step, 60, 1e-5, False
+    return _ExperimentParams(
+        make_A=test_util.hermitian_matrix_eigvals_step,
+        num_samples=60,
+        max_rel_err=1e-5,
+        is_normal=False,
+        requires_x64=False,
+        dtype=dtype,
+    )
 
 
 @testing.parametrize("dtype", [float, complex])
 @testing.parametrize_with_cases(
-    "make_A, num_samples, max_rel_err, is_normal",
+    "make_A, num_samples, max_rel_err, is_normal, requires_x64, dtype",
     cases=".",
     prefix="cases_experiments_",
 )
 def test_xrownorms_squared_reproduce_experiments(
-    make_A, num_samples, max_rel_err, is_normal, dtype
+    make_A, num_samples, max_rel_err, is_normal, requires_x64, dtype
 ):
     """Assert that squared row norms are estimated accurately for structured spectra."""
-    requires_x64 = make_A is test_util.hermitian_matrix_eigvals_decaying
-    if requires_x64:
-        config.update("jax_enable_x64", True)
+    config.update("jax_enable_x64", requires_x64)
     n = 1_000
     num_rep = 10
     key = prng.prng_key(50)
@@ -149,5 +183,4 @@ def test_xrownorms_squared_reproduce_experiments(
     max_rel_errs = np.array_max(np.abs(received - expected) / np.abs(expected), axis=1)
     median_max_rel_err = np.median(max_rel_errs)
     assert float(median_max_rel_err) < max_rel_err
-    if requires_x64:
-        config.update("jax_enable_x64", False)
+    config.update("jax_enable_x64", False)

--- a/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
+++ b/tests/test_stochtrace/test_leave_one_out/test_xrownorms_squared.py
@@ -104,7 +104,9 @@ class _ExperimentParams(NamedTuple):
     requires_x64: bool
     dtype: type
 
-def cases_experiments_exp_normal():
+
+@testing.parametrize("dtype", [float, complex])
+def cases_experiments_exp_normal(dtype):
     """Hermitian matrix with eigenvalues that decay rapidly, XSymRowNorm"""
     return _ExperimentParams(
         make_A=test_util.hermitian_matrix_eigvals_decaying,
@@ -116,7 +118,8 @@ def cases_experiments_exp_normal():
     )
 
 
-def cases_experiments_exp_general():
+@testing.parametrize("dtype", [float, complex])
+def cases_experiments_exp_general(dtype):
     """Hermitian matrix with eigenvalues that decay rapidly, XRowNorm"""
     return _ExperimentParams(
         make_A=test_util.hermitian_matrix_eigvals_decaying,
@@ -128,7 +131,8 @@ def cases_experiments_exp_general():
     )
 
 
-def cases_experiments_step_normal():
+@testing.parametrize("dtype", [float, complex])
+def cases_experiments_step_normal(dtype):
     """Hermitian matrix with eigenvalues that are flat with a sudden drop, XSymRowNorm"""
     return _ExperimentParams(
         make_A=test_util.hermitian_matrix_eigvals_step,
@@ -140,7 +144,8 @@ def cases_experiments_step_normal():
     )
 
 
-def cases_experiments_step_general():
+@testing.parametrize("dtype", [float, complex])
+def cases_experiments_step_general(dtype):
     """Hermitian matrix with eigenvalues that are flat with a sudden drop, XRowNorm"""
     return _ExperimentParams(
         make_A=test_util.hermitian_matrix_eigvals_step,
@@ -152,7 +157,6 @@ def cases_experiments_step_general():
     )
 
 
-@testing.parametrize("dtype", [float, complex])
 @testing.parametrize_with_cases(
     "make_A, num_samples, max_rel_err, is_normal, requires_x64, dtype",
     cases=".",

--- a/tests/test_stochtrace/test_leave_one_out/test_xsymrownorms_squared.py
+++ b/tests/test_stochtrace/test_leave_one_out/test_xsymrownorms_squared.py
@@ -1,4 +1,4 @@
-"""Tests for leave_one_out_xrownorms_squared."""
+"""Tests for leave_one_out_xsymrownorms_squared."""
 
 from matfree import stochtrace, test_util
 from matfree.backend import config, func, linalg, np, prng, testing
@@ -6,7 +6,7 @@ from matfree.backend.typing import Array, Callable, NamedTuple
 
 
 @testing.parametrize("n", [10, 20])
-def test_xrownorms_squared_error_num_samples_more_than_dimension(n):
+def test_xsymrownorms_squared_error_num_samples_more_than_dimension(n):
     """Assert that num_samples greater than the dimension raises a ValueError."""
     key = prng.prng_key(1)
     A = np.eye(n)
@@ -14,7 +14,7 @@ def test_xrownorms_squared_error_num_samples_more_than_dimension(n):
     def matvec(v, A):
         return A @ v
 
-    integrand = stochtrace.leave_one_out_xrownorms_squared()
+    integrand = stochtrace.leave_one_out_xsymrownorms_squared()
     sampler = stochtrace.sampler_signs(np.ones(n), num=n + 1)
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     message = f"Number of samples num={n + 1} exceeds the acceptable range."
@@ -25,14 +25,14 @@ def test_xrownorms_squared_error_num_samples_more_than_dimension(n):
 
 @testing.parametrize("n", [12, 30])
 def cases_exact_num_samples_at_least_dimension(n):
-    """Exact squared row norms when num_samples >= n/3.
+    """Exact squared row norms when num_samples >= n/2.
 
     Uses two differently-sized pytree blocks, also exercising heterogeneous
     pytree support.
     """
     n1 = max(1, n // 3)
     n2 = n - n1
-    num_samples = n // 3
+    num_samples = n // 2
     key_eigvals1, key_eigvals2, key_eigvecs1, key_eigvecs2 = prng.split(
         prng.prng_key(1), 4
     )
@@ -51,7 +51,7 @@ def cases_exact_num_samples_at_least_dimension(n):
     params = (A1, A2)
     x_like = {"x": np.ones(n1), "y": np.ones(n2)}
     sampler = stochtrace.sampler_signs(x_like, num=num_samples)
-    integrand = stochtrace.leave_one_out_xrownorms_squared()
+    integrand = stochtrace.leave_one_out_xsymrownorms_squared()
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     return matvec, params, estimate, expected
 
@@ -62,9 +62,9 @@ def cases_exact_num_samples_more_than_rank(n, rank, dtype):
     """Exact squared row norms when num_samples exceeds the operator's rank."""
     num_samples = rank + 1
     key_mat1, key_mat2 = prng.split(prng.prng_key(1), 2)
-    A1 = prng.normal(key_mat1, shape=(n + 1, rank), dtype=dtype)
-    A2 = prng.normal(key_mat2, shape=(rank, n), dtype=dtype)
-    A = A1 @ A2
+    nz_eigvals = prng.normal(key_mat1, shape=(rank,), dtype=dtype)
+    eigvals = np.concatenate([nz_eigvals, np.zeros(n - rank, dtype=dtype)])
+    A = test_util.hermitian_matrix_from_eigenvalues(eigvals, key_mat2, dtype=dtype)
     expected = {"fx": np.sum(linalg.abs2(A), axis=1)}
 
     def matvec(v, A):
@@ -73,7 +73,7 @@ def cases_exact_num_samples_more_than_rank(n, rank, dtype):
     params = (A,)
     x_like = {"x": np.ones(n, dtype=dtype)}
     sampler = stochtrace.sampler_signs(x_like, num=num_samples)
-    integrand = stochtrace.leave_one_out_xrownorms_squared()
+    integrand = stochtrace.leave_one_out_xsymrownorms_squared()
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
     return matvec, params, estimate, expected
 
@@ -81,7 +81,7 @@ def cases_exact_num_samples_more_than_rank(n, rank, dtype):
 @testing.parametrize_with_cases(
     "matvec, params, estimate, expected", cases=".", prefix="cases_exact_"
 )
-def test_xrownorms_squared_exact(matvec, params, estimate, expected):
+def test_xsymrownorms_squared_exact(matvec, params, estimate, expected):
     """Assert exact squared row norms when num_samples is large enough."""
     key = prng.prng_key(1)
     received = estimate(matvec, key, *params)
@@ -102,8 +102,8 @@ def cases_experiments_exp(dtype):
     """Hermitian matrix with eigenvalues that decay rapidly."""
     return _ExperimentParams(
         make_A=test_util.hermitian_matrix_eigvals_decaying,
-        num_samples=35,
-        max_rel_err=1e-9,
+        num_samples=50,
+        max_rel_err=1e-12,
         requires_x64=True,
         dtype=dtype,
     )
@@ -115,7 +115,7 @@ def cases_experiments_step(dtype):
     return _ExperimentParams(
         make_A=test_util.hermitian_matrix_eigvals_step,
         num_samples=60,
-        max_rel_err=1e-5,
+        max_rel_err=9e-3,
         requires_x64=False,
         dtype=dtype,
     )
@@ -126,7 +126,7 @@ def cases_experiments_step(dtype):
     cases=".",
     prefix="cases_experiments_",
 )
-def test_xrownorms_squared_reproduce_experiments(
+def test_xsymrownorms_squared_reproduce_experiments(
     make_A, num_samples, max_rel_err, requires_x64, dtype
 ):
     """Assert that squared row norms are estimated accurately for structured spectra."""
@@ -140,7 +140,7 @@ def test_xrownorms_squared_reproduce_experiments(
 
     x_like = {"x": np.ones(n, dtype=dtype)}
     sampler = stochtrace.sampler_signs(x_like, num=num_samples)
-    integrand = stochtrace.leave_one_out_xrownorms_squared()
+    integrand = stochtrace.leave_one_out_xsymrownorms_squared()
     estimate = stochtrace.estimator_leave_one_out(integrand, sampler)
 
     def matvec(v, A):

--- a/tests/test_stochtrace/test_monte_carlo/test_rownorms_squared.py
+++ b/tests/test_stochtrace/test_monte_carlo/test_rownorms_squared.py
@@ -1,0 +1,104 @@
+"""Test the estimation of squared row norms."""
+
+from matfree import stochtrace, test_util
+from matfree.backend import func, linalg, np, prng, testing, tree
+
+
+@testing.parametrize("seed", [1, 2, 3])
+@testing.parametrize("dtype", [float, complex])
+def test_rownorms_squared(seed, dtype):
+    """Assert that the estimated squared row norms approximate the true values accurately."""
+
+    def fun(x):
+        """Create a nonlinear, to-be-differentiated function."""
+        fx = np.sin(np.flip(np.cos(x["params"])) + 1.0) * np.sin(x["params"])
+        return {"params": fx}
+
+    key = prng.prng_key(seed)
+
+    # Linearise function
+    key, subkey = prng.split(key, num=2)
+    x0 = prng.normal(subkey, shape=(4,), dtype=dtype)
+    args_like = {"params": x0}
+    _, jvp = func.linearize(fun, args_like)
+    J = func.jacfwd(fun, holomorphic=dtype is complex)(args_like)["params"]
+
+    expected = tree.tree_map(lambda j: np.sum(linalg.abs2(j), axis=1), J)
+
+    # Estimate the matrix function
+    integrand = stochtrace.monte_carlo_rownorms_squared()
+    sampler = stochtrace.sampler_normal(args_like, num=100_000)
+    estimate = stochtrace.estimator_monte_carlo(integrand, sampler=sampler)
+    key, subkey = prng.split(key, num=2)
+    received = estimate(jvp, subkey)
+
+    def compare(a, b):
+        return np.allclose(a, b, rtol=0.05, atol=0.05)
+
+    assert tree.tree_all(tree.tree_map(compare, received, expected))
+
+
+@testing.parametrize("dtype", [float, complex])
+def test_rownorms_squared_sums_to_frobeniusnorm_squared(dtype):
+    """Assert that summing the squared row norms over all entries gives the squared Frobenius norm.
+
+    This identity, sum_i rownorms_squared(v)[i] == frobeniusnorm_squared(v), holds exactly
+    for every sample vector v (not just in expectation), since sum_i |x_i|^2 = vdot(x, x).
+    Also exercises heterogeneous pytree support via two differently-sized blocks.
+    """
+    n1, n2 = 3, 5
+    key_mat1, key_mat2, key_v = prng.split(prng.prng_key(1), 3)
+    A1 = prng.normal(key_mat1, shape=(n1, n1), dtype=dtype)
+    A2 = prng.normal(key_mat2, shape=(n2, n2), dtype=dtype)
+
+    def matvec(v, A1, A2):
+        return {"fx": A1 @ v["fx"], "fy": A2 @ v["fy"]}
+
+    x_like = {"fx": np.ones(n1, dtype=dtype), "fy": np.ones(n2, dtype=dtype)}
+    v = test_util.tree_random_like(key_v, x_like)
+
+    rownorms_squared = stochtrace.monte_carlo_rownorms_squared()
+    frobeniusnorm_squared = stochtrace.monte_carlo_frobeniusnorm_squared()
+
+    rownorms_out = rownorms_squared(matvec, v, A1, A2)
+    frobenius_out = frobeniusnorm_squared(matvec, v, A1, A2)
+
+    assert set(rownorms_out.keys()) == {"fx", "fy"}
+    total = sum(np.sum(leaf) for leaf in tree.tree_leaves(rownorms_out))
+    test_util.assert_allclose(total, frobenius_out)
+
+
+@testing.parametrize("dtype", [float, complex])
+def test_rownorms_squared_rectangular(dtype):
+    """Assert correct squared row norms for a rectangular (non-square) matvec."""
+    m, n = 6, 10
+    key_mat, key_est = prng.split(prng.prng_key(2), 2)
+    A = prng.normal(key_mat, shape=(m, n), dtype=dtype)
+    expected = np.sum(linalg.abs2(A), axis=1)
+
+    def matvec(v, A):
+        return A @ v
+
+    integrand = stochtrace.monte_carlo_rownorms_squared()
+    sampler = stochtrace.sampler_normal(np.ones(n, dtype=dtype), num=200_000)
+    estimate = stochtrace.estimator_monte_carlo(integrand, sampler=sampler)
+    received = estimate(matvec, key_est, A)
+    assert np.allclose(received, expected, rtol=0.05, atol=0.05)
+
+
+@testing.parametrize("dtype", [float, complex])
+def test_rownorms_squared_adjoint_gives_column_norms(dtype):
+    """Assert that passing the adjoint matvec estimates squared column norms instead."""
+    m, n = 6, 10
+    key_mat, key_est = prng.split(prng.prng_key(3), 2)
+    A = prng.normal(key_mat, shape=(m, n), dtype=dtype)
+    expected = np.sum(linalg.abs2(A), axis=0)
+
+    def matvec_adjoint(v, A):
+        return A.T.conj() @ v
+
+    integrand = stochtrace.monte_carlo_rownorms_squared()
+    sampler = stochtrace.sampler_normal(np.ones(m, dtype=dtype), num=200_000)
+    estimate = stochtrace.estimator_monte_carlo(integrand, sampler=sampler)
+    received = estimate(matvec_adjoint, key_est, A)
+    assert np.allclose(received, expected, rtol=0.05, atol=0.05)


### PR DESCRIPTION
As proposed in #284, this PR adds
- [x] `monte_carlo_rownorms_squared` (JL)
- [x] `leave_one_out_xrownorms_squared`
- [x] `leave_one_out_xsymrownorms_squared`

Closes #284 

## Empirical comparison with thesis experiments

The LOO estimator(s) are introduced in Chapter 17 of Ethan Epperley's thesis, and Figure 17.2 (below) compares their performance on the same test matrices we've been using in the other PRs. Below I ran the same experiments with these implementations and saw nearly identical results:
<img width="400" alt="Screenshot_2026-06-24_18-51-05" src="https://github.com/user-attachments/assets/5088bf9d-bfa2-49cd-8a21-156f9a372c32" />
<img width="400" alt="fig17-2_repro" src="https://github.com/user-attachments/assets/8e3ae007-8825-481b-878e-74b9bc4c78c6" />
