### PR TITLE
Fix Hermitian Lanczos for complex matrices

### DIFF
--- a/matfree/decomp.py
+++ b/matfree/decomp.py
@@ -130,7 +130,7 @@ def _tridiag_reortho_full(num_matvecs: int, /, *, custom_vjp: bool, materialize:
     def estimate(matvec, vec, *params):
         Q, H, v, norm = alg(matvec, vec, *params)
 
-        T = 0.5 * (H + H.T)
+        T = 0.5 * (H + H.T.conj())
         diags = linalg.diagonal(T, offset=0)
         offdiags = linalg.diagonal(T, offset=1)
 
@@ -219,9 +219,9 @@ def _tridiag_reortho_none(num_matvecs: int, /, *, custom_vjp: bool, materialize:
 
 def _tridiag_forward(matvec, num_matvecs, vec, *params):
     # Pre-allocate
-    vectors = np.zeros((num_matvecs + 1, len(vec)))
-    offdiags = np.zeros((num_matvecs,))
-    diags = np.zeros((num_matvecs,))
+    vectors = np.zeros((num_matvecs + 1, len(vec)), dtype=vec.dtype)
+    offdiags = np.zeros((num_matvecs,), dtype=vec.dtype)
+    diags = np.zeros((num_matvecs,), dtype=vec.dtype)
 
     # Normalize (not all Lanczos implementations do that)
     v0 = vec / linalg.vector_norm(vec)
@@ -261,7 +261,7 @@ def _tridiag_fwd_init(matvec, vec, *params):
     for x_{k+1}, a_k, and b_k, using
     orthogonality of the x_k.
     """
-    a = vec @ (matvec(vec, *params))
+    a = linalg.vdot(vec, matvec(vec, *params))
     r = (matvec(vec, *params)) - a * vec
     b = linalg.vector_norm(r)
     x = r / b
@@ -285,7 +285,7 @@ def _tridiag_fwd_step(matvec, params, i, val):
 
 def _tridiag_fwd_step_apply(matvec, vec, b, vec_previous, *params):
     """Apply Lanczos' recurrence."""
-    a = vec @ (matvec(vec, *params))
+    a = linalg.vdot(vec, matvec(vec, *params))
     r = matvec(vec, *params) - a * vec - b * vec_previous
     b = linalg.vector_norm(r)
     x = r / b
@@ -353,8 +353,8 @@ def hessenberg(
 ):
     r"""Construct a **Hessenberg-factorisation** via the Arnoldi iteration.
 
-    Factorise $A \approx Q H Q^\top$, where $Q$ is orthogonal and $H$ is upper Hessenberg.
-    Works for **arbitrary square matrices**. Does not support complex-valued matrices.
+    Factorise $A \approx Q H Q^H$, where $Q$ is orthonormal and $H$ is upper Hessenberg.
+    Works for **arbitrary square matrices** including complex-valued matrices.
 
     Setting `custom_vjp` to `True` implies using efficient, numerically stable
     gradients of the Arnoldi iteration which was proposed by Krämer et al. (2024).
@@ -432,7 +432,7 @@ def _hessenberg_forward(matvec, num_matvecs, v, *params, reortho: str):
     (n,), k = np.shape(v), num_matvecs
     Q = np.zeros((n, k), dtype=v.dtype)
     H = np.zeros((k, k), dtype=v.dtype)
-    initlength = np.sqrt(linalg.inner(v, v))
+    initlength = np.sqrt(linalg.vdot(v, v))
     init = (Q, H, v, initlength)
 
     if num_matvecs == 0:
@@ -460,15 +460,15 @@ def _hessenberg_forward_step(Q, H, v, length, matvec, *params, idx, reortho: str
     v = matvec(v, *params)
 
     # Orthonormalise
-    h = Q.T @ v
+    h = Q.T.conj() @ v
     v = v - Q @ h
 
     # Re-orthonormalise
     if reortho != "none":
-        v = v - Q @ (Q.T @ v)
+        v = v - Q @ (Q.T.conj() @ v)
 
     # Read the length
-    length = np.sqrt(linalg.inner(v, v))
+    length = np.sqrt(linalg.vdot(v, v))
 
     # Save
     h = h.at[idx + 1].set(length)

--- a/matfree/test_util.py
+++ b/matfree/test_util.py
@@ -62,7 +62,7 @@ def tree_random_like(key, pytree, *, generate_func=prng.normal):
 
 def assert_columns_orthonormal(Q, /):
     """Assert that the columns in a matrix are orthonormal."""
-    eye_like = Q.T @ Q
+    eye_like = Q.T.conj() @ Q
     ref = np.eye(len(eye_like))
     assert_allclose(eye_like, ref)
 

--- a/tests/test_decomp/test_hessenberg.py
+++ b/tests/test_decomp/test_hessenberg.py
@@ -7,7 +7,7 @@ from matfree.backend import linalg, np, prng, testing
 @testing.parametrize("nrows", [10])
 @testing.parametrize("num_matvecs", [0, 5, 9])
 @testing.parametrize("reortho", ["none", "full"])
-@testing.parametrize("dtype", [float])
+@testing.parametrize("dtype", [float, complex])
 def test_decomposition_is_satisfied(nrows, num_matvecs, reortho, dtype):
     # Create a well-conditioned test-matrix
     A = prng.normal(prng.prng_key(1), shape=(nrows, nrows), dtype=dtype)
@@ -65,7 +65,7 @@ def test_reorthogonalisation_improves_the_estimate(nrows, num_matvecs, reortho):
     # Test the decompositions
     e0, ek = np.eye(num_matvecs)[[0, -1], :]
     test_util.assert_allclose(A @ Q.T - Q.T @ H - linalg.outer(r, ek), 0.0)
-    test_util.assert_allclose(Q @ Q.T - np.eye(num_matvecs), 0.0)
+    test_util.assert_allclose(Q @ Q.T.conj() - np.eye(num_matvecs), 0.0)
     test_util.assert_allclose(Q.T @ e0, c * v)
 
 

--- a/tests/test_decomp/test_tridiag_sym.py
+++ b/tests/test_decomp/test_tridiag_sym.py
@@ -6,11 +6,14 @@ from matfree.backend import linalg, np, prng, testing
 
 @testing.parametrize("reortho", ["full", "none"])
 @testing.parametrize("ndim", [12])
-def test_full_rank_reconstruction_is_exact(reortho, ndim):
+@testing.parametrize("dtype", [float, complex])
+def test_full_rank_reconstruction_is_exact(reortho, ndim, dtype):
     # Set up a test-matrix and an initial vector
     eigvals = np.arange(1.0, 2.0, step=1 / ndim)
-    matrix = test_util.hermitian_matrix_from_eigenvalues(eigvals, prng.prng_key(1))
-    vector = np.flip(np.arange(1.0, 1.0 + len(eigvals)))
+    matrix = test_util.hermitian_matrix_from_eigenvalues(
+        eigvals, prng.prng_key(1), dtype=dtype
+    )
+    vector = np.flip(np.arange(1.0, 1.0 + len(eigvals))).astype(dtype)
 
     def matvec(s, p):
         [(x,)] = s
@@ -23,7 +26,7 @@ def test_full_rank_reconstruction_is_exact(reortho, ndim):
 
     # Reconstruct the original matrix from the full-num_matvecs approximation
     # Q shape is (k, n) -- rows are Krylov vectors
-    matrix_reconstructed = Q.T @ T @ Q
+    matrix_reconstructed = Q.T @ T @ Q.conj()
 
     if reortho == "full":
         tols = {"atol": 1e-5, "rtol": 1e-5}
@@ -43,11 +46,16 @@ def test_full_rank_reconstruction_is_exact(reortho, ndim):
 @testing.parametrize("num_matvecs", [1, 5, 11])
 @testing.parametrize("ndim", [12])
 @testing.parametrize("reortho", ["full", "none"])
-def test_mid_rank_reconstruction_satisfies_decomposition(ndim, num_matvecs, reortho):
+@testing.parametrize("dtype", [float, complex])
+def test_mid_rank_reconstruction_satisfies_decomposition(
+    ndim, num_matvecs, reortho, dtype
+):
     # Set up a test-matrix and an initial vector
     eigvals = np.arange(1.0, 2.0, step=1 / ndim)
-    matrix = test_util.hermitian_matrix_from_eigenvalues(eigvals, prng.prng_key(1))
-    vector = np.flip(np.arange(1.0, 1.0 + len(eigvals)))
+    matrix = test_util.hermitian_matrix_from_eigenvalues(
+        eigvals, prng.prng_key(1), dtype=dtype
+    )
+    vector = np.flip(np.arange(1.0, 1.0 + len(eigvals))).astype(dtype)
 
     def matvec(s, p):
         [(x,)] = s

--- a/tests/test_eig/test_eigh_partial.py
+++ b/tests/test_eig/test_eigh_partial.py
@@ -20,6 +20,23 @@ def test_equal_to_linalg_eigh(nrows):
     assert np.allclose(vals, S)
 
 
+@testing.parametrize("nrows", [48])
+@testing.parametrize("num_matvecs", [24])
+def test_ritz_values_stay_bounded_for_complex_hermitian(nrows, num_matvecs):
+    C = prng.normal(prng.prng_key(1), shape=(nrows, nrows), dtype=complex)
+    A = C @ C.T.conj() + nrows * np.eye(nrows)
+    v0 = np.ones((nrows,), dtype=A.dtype)
+
+    tridiag_sym = decomp.tridiag_sym(num_matvecs, reortho="full")
+    alg = eig.eigh_partial(tridiag_sym)
+    vals, _ = alg(lambda v, p: p @ v, v0, A)
+
+    true_vals, _ = linalg.eigh(A)
+    assert np.array_max(vals) <= np.array_max(true_vals) + 1e-6 * np.array_max(
+        true_vals
+    )
+
+
 @testing.parametrize("nrows", [8])
 @testing.parametrize("num_matvecs", [8, 4, 0])
 def test_shapes_as_expected_vector(nrows, num_matvecs):


### PR DESCRIPTION
Hi @pnkraemer,
Thank you for the nice package. I have been using matfree to solve a Hermitian eigenvalue stability problem. However, I realized that with a complex matrix, matfree requires some minor modifications for it to work correctly. 

## Summary
- use the conjugating inner product in Arnoldi/Hessenberg projections and norms
- symmetrize tridiagonal matrices with the Hermitian transpose
- update the direct Lanczos path and tests for complex Hermitian matrices

## Tests
- `python -m pytest` (415 passed)